### PR TITLE
fix: 部分圖片路徑從大寫改為小寫

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,13 +9,13 @@ definePageMeta({
 // Header-related logic has been moved to layouts/main.vue
 
 const partners = [
-  { name: 'Scuba Schools International', logo: '/img/home/home-SSI-logo.webp' },
-  { name: 'Google', logo: '/img/home/home-Google-logo.webp' },
-  { name: 'Hexschool', logo: '/img/home/home-Hexschool-logo.webp' },
-  { name: 'LinkedIn', logo: '/img/home/home-LinkedIn-logo.webp' },
+  { name: 'Scuba Schools International', logo: '/img/home/home-ssi-logo.webp' },
+  { name: 'Google', logo: '/img/home/home-google-logo.webp' },
+  { name: 'Hexschool', logo: '/img/home/home-hexschool-logo.webp' },
+  { name: 'LinkedIn', logo: '/img/home/home-linkedin-logo.webp' },
   { name: '104 Job Bank', logo: '/img/home/home-104-logo.webp' },
-  { name: 'Cathay United Bank', logo: '/img/home/home-CathayBK-logo.webp' },
-  { name: 'Microsoft', logo: '/img/home/home-Microsoft-logo.webp' }
+  { name: 'Cathay United Bank', logo: '/img/home/home-cathaybk-logo.webp' },
+  { name: 'Microsoft', logo: '/img/home/home-microsoft-logo.webp' }
 ]
 
 // Footer State ---


### PR DESCRIPTION
### 解決什麼問題？ (What does this solve?)

本次 Vercel 部署在建置階段 (Build Step) 失敗，錯誤日誌顯示 `[vite:asset] Could not load ... try-before-you-dive-bg.webp`。

這表示在 `pages/index.vue` 中引用的圖片路徑，因使用了非標準的別名，導致在 Vercel 的建置環境中無法被正確解析，進而造成建置中斷。此 PR 旨在修正此路徑問題，讓部署流程恢復正常。

---

### 如何實現？ (How is this implemented?)

*   檢查 `pages/index.vue` 檔案，找出兩處引用 `try-before-you-dive-bg.webp` 圖片的 `<img>` 標籤。
*   將其 `src` 屬性中的路徑從 `~assets/` 開頭，修改為 Nuxt 3 / Vite 官方推薦且更穩定的 `@/assets/` 別名，以確保在所有環境中都能被正確解析。

---

### 如何手動測試？ (How to test this manually?)

此錯誤主要發生於 Vercel 的建置環境，因此最主要的驗證方式是**確認此 PR 觸發的 Vercel 預覽部署 (Preview Deployment) 是否能够成功建置 (Build) 並顯示為 Ready 狀態**。

作為輔助驗證，可在本地執行：
1.  `pnpm build`
2.  `pnpm preview`
3.  打開 `http://localhost:3000` 並檢查首頁，確認「我們的合作夥伴」區塊的背景圖正常顯示，且瀏覽器控制台無相關錯誤。
