### PR TITLE
fix/deploy: 修正上傳流程， github拿到新內容

### DIFF
--- a/project-steps.md
+++ b/project-steps.md
@@ -23,3 +23,5 @@
 # 加入 font awsome
 
 # 新增 layouts/main
+
+# 修復 git push 新內容時，gitgub 拿取新內容失敗問題


### PR DESCRIPTION
錯誤訊息的訊息源頭：

在 Vercel 的 Linux 建置環境中，檔案系統是嚴格區分大小寫的。

先前的程式碼在 pages/index.vue 中，引用了全小寫路徑的圖片 (`try-before-you-dive-bg.webp`)，但儲存庫中的實際檔名卻是開頭大寫 (`Try-Before-You-Dive-bg.webp`)。

這種不一致在不區分大小寫的本地開發環境 (如 Windows) 中不會出現問題，但在 Vercel 上會導致 `Could not load ...` 的建置錯誤。

此提交統一將圖片的實際檔名與程式碼中的引用路徑，全部修正為小寫，以從根本上解決此跨平台部署問題。

問題根源：

github 上的 main 無正確吸收來自 dev, feat/fix-bug 的修補後原始碼，起因是在我刪除雲端的 feat/fix-big 分支後，結果我忘記此事，使得我持續推送新原始碼到已刪除(當下已失效的分支)的 feat/fix-bug 分支。

而基於此錯誤，在此之後的 feat/fix-big -> dev, dev -> main ，這兩者的 PR 全都使用舊資料在傳遞，所以 vercel 那端才會一直回報最初的錯誤，讓我誤以為我修復失敗。