### PR TITLE
Ep10 new plan

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -17,11 +17,11 @@
     -webkit-mask-image: linear-gradient(to left, black 50%, transparent 80%);
   }
 
-  .btn-brand-yellow {
+  .el-button.btn-brand-yellow {
     @apply bg-btn-yellow text-black font-bold py-2 px-4 rounded transition-transform duration-300;
   }
 
-  .btn-brand-yellow:hover {
+  .el-button.btn-brand-yellow:hover {
     color: #FF0000;
     transform: scale(1.2);
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,12 +18,9 @@
   }
 
   .el-button.btn-brand-yellow {
-    @apply bg-btn-yellow text-black font-bold py-2 px-4 rounded transition-transform duration-300;
-  }
-
-  .el-button.btn-brand-yellow:hover {
-    color: #FF0000;
-    transform: scale(1.2);
+    @apply bg-btn-yellow text-black font-bold py-2 px-4 rounded 
+           transition-all duration-300 
+           hover:bg-[#ffe70c] hover:scale-105;
   }
 
   .btn-danger-outline {

--- a/layouts/company.vue
+++ b/layouts/company.vue
@@ -14,6 +14,7 @@ import { companyRoutes as r } from '~/utils/companyRoutes';
 
 const router = useRouter();
 const programsPath = router.resolve(r.landing()).path;  // 計畫列表
+const newProgramPath = router.resolve(r.newProgram()).path; // 新增體驗
 </script>
 
 <template>
@@ -52,7 +53,7 @@ const programsPath = router.resolve(r.landing()).path;  // 計畫列表
             <el-icon><icon-menu /></el-icon>
             <span>計畫列表</span>
           </el-menu-item>
-          <el-menu-item index="#">
+          <el-menu-item :index="newProgramPath">
             <el-icon><Plus /></el-icon>
             <span>新增體驗</span>
           </el-menu-item>

--- a/pages/company/programs/new.vue
+++ b/pages/company/programs/new.vue
@@ -1,0 +1,175 @@
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { Plus } from '@element-plus/icons-vue';
+
+definePageMeta({
+  layout: 'company',
+  name: 'company-programs-new',
+});
+
+const form = ref({
+  title: '',
+  industry: '',
+  jobCategory: '',
+  location: '',
+  contactPerson: '',
+  contactPhone: '',
+  description: [
+    { title: '體驗介紹', content: '' },
+    { title: '行程安排', content: '' },
+    { title: '收穫', content: '' },
+  ],
+  customItems: [{ content: '這邊是預計給使用者自訂項目的編輯器\n- 說明1\n- 說明2\n- 說明3' }],
+  attendees: '1-5人',
+  startDate: '',
+  duration: '',
+  images: [],
+  agree: false,
+});
+
+function addDescriptionField() {
+  if (form.value.description.length < 5) {
+    form.value.description.push({ title: '自定義項目', content: '' });
+  }
+}
+</script>
+
+<template>
+  <div class="p-6 bg-white rounded-lg shadow-sm">
+    <div class="flex justify-between items-center mb-6">
+      <h2 class="text-2xl font-bold">
+        新增體驗計畫
+      </h2>
+      <el-button type="primary" plain>
+        購買方案
+      </el-button>
+    </div>
+
+    <div class="p-4 mb-6 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+      目前的方案 <span class="font-medium">已過期</span> 體驗人數 <span class="font-medium">已達上限</span>
+    </div>
+
+    <el-form :model="form" label-position="top">
+      <el-form-item label="體驗名稱 (最多10個字)">
+        <el-input v-model="form.title" placeholder="計劃輸入匡" />
+      </el-form-item>
+      <el-form-item label="體驗名稱 (最多10個字)">
+        <div class="p-4 border rounded-md bg-gray-50 w-full">
+          <p>您可以描述</p>
+          <ul class="list-decimal list-inside text-gray-500">
+            <li>體驗計畫的內容與目標</li>
+            <li>師資陣容與經歷</li>
+            <li>行前須知和注意事項</li>
+            <li>參加體驗的門檻或限制</li>
+          </ul>
+        </div>
+      </el-form-item>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="產業類別">
+            <el-select v-model="form.industry" placeholder="搜尋計劃名稱" class="w-full">
+              <!-- options here -->
+            </el-select>
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="職務類別">
+            <el-select v-model="form.jobCategory" placeholder="請選擇職務類別" class="w-full">
+              <!-- options here -->
+            </el-select>
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-form-item label="體驗地址">
+        <el-input v-model="form.location" placeholder="請輸入體驗地點的完整地址" />
+      </el-form-item>
+
+      <el-row :gutter="20">
+        <el-col :span="12">
+          <el-form-item label="聯絡人">
+            <el-input v-model="form.contactPerson" placeholder="請輸入聯絡人姓名" />
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="電話">
+            <el-input v-model="form.contactPhone" placeholder="請輸入聯絡電話" />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <el-form-item label="計畫詳細說明 (計劃說明最多可新增至五個階段)">
+        <div v-for="(item, index) in form.description" :key="index" class="w-full mb-4">
+          <label class="font-medium">階段 {{ index + 1 }}: {{ item.title }}</label>
+          <el-input v-model="item.content" type="textarea" :rows="3" placeholder="描述此階段的內容、時間與目標" />
+          <div v-if="index > 2" class="text-right mt-1">
+            <el-button text size="small">
+              編輯
+            </el-button>
+          </div>
+        </div>
+        <div v-for="(item, index) in form.customItems" :key="index" class="w-full mb-4">
+          <label class="font-medium">階段 {{ form.description.length + index + 1 }}: 請輸入自定義項目</label>
+          <div class="border rounded-md p-4">
+            <!-- Simplified editor view -->
+            <div class="prose" v-html="item.content.replace(/\n/g, '<br>')"></div>
+          </div>
+        </div>
+
+        <el-button :icon="Plus" @click="addDescriptionField" :disabled="form.description.length >= 5">
+          新增階段
+        </el-button>
+      </el-form-item>
+
+      <el-form-item label="計畫日期與照片">
+        <el-row :gutter="20" class="w-full">
+          <el-col :span="12">
+            <el-form-item label="體驗人數">
+              <el-select v-model="form.attendees" class="w-full">
+                <el-option label="1-5 人" value="1-5人" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="體驗刊登開始日期">
+              <el-date-picker v-model="form.startDate" type="date" placeholder="請選擇開始日期" class="w-full" />
+            </el-form-item>
+            <el-form-item label="刊登期間">
+              <el-select v-model="form.duration" placeholder="請選擇刊登期間" class="w-full">
+                <!-- options here -->
+              </el-select>
+              <p class="text-sm text-gray-500">
+                結束日期 2025/9/10
+              </p>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="體驗照片 (最多四張)">
+              <el-upload
+                action="#"
+                list-type="picture-card"
+                :auto-upload="false"
+                multiple
+                :limit="4"
+              >
+                <el-icon><Plus /></el-icon>
+              </el-upload>
+            </el-form-item>
+          </el-col>
+        </el-row>
+      </el-form-item>
+
+      <el-form-item>
+        <el-checkbox v-model="form.agree">
+          我已閱讀並同意 <el-link type="primary">服務條款</el-link> 與 <el-link type="primary">隱私權政策</el-link>
+        </el-checkbox>
+      </el-form-item>
+
+      <el-form-item>
+        <el-button>預覽</el-button>
+        <el-button type="primary">
+          送出
+        </el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template> 

--- a/pages/company/programs/new.vue
+++ b/pages/company/programs/new.vue
@@ -36,19 +36,19 @@ function addDescriptionField() {
 
 <template>
   <div class="p-6 bg-white rounded-lg shadow-sm">
-    <div class="flex justify-between items-center mb-6">
-      <h2 class="text-2xl font-bold">
-        新增體驗計畫
-      </h2>
-      <el-button type="primary" plain>
+    
+
+    <div class="mb-6 flex justify-between items-center" role="alert">
+      <div class="text-sm text-red-500">
+        目前的方案 <span class="font-medium">已過期</span> 體驗人數 <span class="font-medium">已達上限</span>
+      </div>
+      <el-button class="btn-brand-yellow">
         購買方案
       </el-button>
     </div>
-
-    <div class="p-4 mb-6 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-      目前的方案 <span class="font-medium">已過期</span> 體驗人數 <span class="font-medium">已達上限</span>
-    </div>
-
+    <h2 class="text-2xl font-bold mb-6">
+      新增體驗計畫
+    </h2>
     <el-form :model="form" label-position="top">
       <el-form-item label="體驗名稱 (最多10個字)">
         <el-input v-model="form.title" placeholder="計劃輸入匡" />

--- a/pages/company/programs/new.vue
+++ b/pages/company/programs/new.vue
@@ -9,6 +9,7 @@ definePageMeta({
 
 const form = ref({
   title: '',
+  summary: '',
   industry: '',
   jobCategory: '',
   location: '',
@@ -42,7 +43,7 @@ function addDescriptionField() {
       <div class="text-sm text-red-500">
         目前的方案 <span class="font-medium">已過期</span> 體驗人數 <span class="font-medium">已達上限</span>
       </div>
-      <el-button class="btn-brand-yellow">
+      <el-button type="primary">
         購買方案
       </el-button>
     </div>
@@ -51,18 +52,15 @@ function addDescriptionField() {
     </h2>
     <el-form :model="form" label-position="top">
       <el-form-item label="體驗名稱 (最多10個字)">
-        <el-input v-model="form.title" placeholder="計劃輸入匡" />
+        <el-input v-model="form.title" placeholder="計劃輸入框" />
       </el-form-item>
-      <el-form-item label="體驗名稱 (最多10個字)">
-        <div class="p-4 border rounded-md bg-gray-50 w-full">
-          <p>您可以描述</p>
-          <ul class="list-decimal list-inside text-gray-500">
-            <li>體驗計畫的內容與目標</li>
-            <li>師資陣容與經歷</li>
-            <li>行前須知和注意事項</li>
-            <li>參加體驗的門檻或限制</li>
-          </ul>
-        </div>
+      <el-form-item label="體驗介紹">
+        <el-input
+          v-model="form.summary"
+          type="textarea"
+          :rows="6"
+          placeholder="您可以描述&#10;1. 體驗計畫的內容與目標&#10;2. 師資陣容與經歷&#10;3. 行前須知和注意事項&#10;4. 參加體驗的門檻或限制"
+        />
       </el-form-item>
 
       <el-row :gutter="20">

--- a/project-steps.md
+++ b/project-steps.md
@@ -95,3 +95,9 @@
   - 在 `pages/company/programs/new.vue` 中，根據設計稿使用 Element Plus 元件 (`el-form`, `el-input`, `el-select`, `el-date-picker`, `el-upload` 等) 建構了完整的表單結構。
   - 實作了頁面頂部的「方案狀態」提示橫幅。
   - 完成了包含所有欄位、按鈕與基本版面配置的頁面初版。
+
+# 2025-07-29
+### EP10: 新增體驗計畫頁面
+- **表單元件優化**:
+  - 根據設計稿，將 `pages/company/programs/new.vue` 中的靜態提示區塊，重構為一個功能性的多行文字輸入框 (`<el-input type="textarea">`)。
+  - 為新的輸入框新增了 `summary` 狀態，並將原有的提示文字轉換為 `placeholder`，提升了表單的互動性與可用性。

--- a/project-steps.md
+++ b/project-steps.md
@@ -84,3 +84,14 @@
 - **路由問題修復**：
   - 解決了因 `definePageMeta` 的 `name` 與 `userRoutes.ts` 中定義不一致而導致的 `No match found` 路由錯誤。
   - 統一了專案內的路由命名風格，將駝峰式命名改為 kebab-case，提升了可讀性與一致性。
+
+# 2025-07-28
+### EP10: 新增體驗計畫頁面
+- **頁面建立與路由設定**：
+  - 建立了「新增體驗計畫」頁面檔案 `pages/company/programs/new.vue`，並設定其使用 `company` 佈局。
+  - 在 `utils/companyRoutes.ts` 中為新頁面新增了路由 `newProgram`，並在頁面中透過 `definePageMeta` 進行綁定。
+  - 更新了 `layouts/company.vue` 中的側邊導覽列，將「新增體驗」按鈕正確連結至新頁面。
+- **表單介面實作**：
+  - 在 `pages/company/programs/new.vue` 中，根據設計稿使用 Element Plus 元件 (`el-form`, `el-input`, `el-select`, `el-date-picker`, `el-upload` 等) 建構了完整的表單結構。
+  - 實作了頁面頂部的「方案狀態」提示橫幅。
+  - 完成了包含所有欄位、按鈕與基本版面配置的頁面初版。

--- a/utils/companyRoutes.ts
+++ b/utils/companyRoutes.ts
@@ -20,4 +20,5 @@ export const companyRoutes = {
     name: 'companyProgramsApplicantsDetail',
     params: { applicantId },
   }),
+  newProgram: () => ({ name: 'company-programs-new' }),
 }; 


### PR DESCRIPTION
# 2025-07-28
### EP10: 新增體驗計畫頁面
- **頁面建立與路由設定**：
  - 建立了「新增體驗計畫」頁面檔案 `pages/company/programs/new.vue`，並設定其使用 `company` 佈局。
  - 在 `utils/companyRoutes.ts` 中為新頁面新增了路由 `newProgram`，並在頁面中透過 `definePageMeta` 進行綁定。
  - 更新了 `layouts/company.vue` 中的側邊導覽列，將「新增體驗」按鈕正確連結至新頁面。
- **表單介面實作**：
  - 在 `pages/company/programs/new.vue` 中，根據設計稿使用 Element Plus 元件 (`el-form`, `el-input`, `el-select`, `el-date-picker`, `el-upload` 等) 建構了完整的表單結構。
  - 實作了頁面頂部的「方案狀態」提示橫幅。
  - 完成了包含所有欄位、按鈕與基本版面配置的頁面初版。

# 2025-07-29
### EP10: 新增體驗計畫頁面
- **表單元件優化**:
  - 根據設計稿，將 `pages/company/programs/new.vue` 中的靜態提示區塊，重構為一個功能性的多行文字輸入框 (`<el-input type="textarea">`)。
  - 為新的輸入框新增了 `summary` 狀態，並將原有的提示文字轉換為 `placeholder`，提升了表單的互動性與可用性。