### PR TITLE
Feat/UI up1 users login

### DIFF
--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -1,11 +1,112 @@
 <script setup lang="ts">
 definePageMeta({
   name: 'user-login',
-  layout: 'user',
-});
+  layout: 'user'
+})
 </script>
 
 <!-- up1 體驗者登入頁 -->
 <template>
-  <h1 class="text-3xl font-bold underline">up1 體驗者登入頁</h1>
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div class="w-full max-w-md space-y-8">
+      <div>
+        <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          歡迎回來
+        </h2>
+        <p class="mt-2 text-center text-sm text-gray-600">
+          請登入您的帳戶以繼續使用平台服務
+        </p>
+      </div>
+      <form
+        class="mt-8 space-y-6"
+        action="#"
+        method="POST"
+      >
+        <div class="rounded-md  -space-y-px">
+          <div>
+            <label
+              for="email-address"
+              class="block text-sm font-medium text-gray-700"
+            >電子郵件</label>
+            <input
+              id="email-address"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+              class="mt-1 block w-full rounded-md border-gray-300 px-1 py-2 shadow-sm focus:outline-none sm:text-sm"
+              placeholder="請輸入您的電子郵件"
+            >
+          </div>
+          <div class="pt-4">
+            <div class="flex items-center justify-between">
+              <label
+                for="password"
+                class="block text-sm font-medium text-gray-700"
+              >密碼</label>
+              <div class="text-sm">
+                <a href="#">忘記密碼？</a>
+              </div>
+            </div>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autocomplete="current-password"
+              required
+              class="mt-1 block w-full rounded-md border-gray-300 px-1 py-2 shadow-sm focus:outline-none sm:text-sm"
+              placeholder="請輸入您的密碼"
+            >
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <div class="flex items-center">
+            <input
+              id="remember-me"
+              name="remember-me"
+              type="checkbox"
+              class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            >
+            <label
+              for="remember-me"
+              class="ml-2 block text-sm text-gray-900"
+            >記住我的登入資訊</label>
+          </div>
+        </div>
+
+        <div>
+          <button
+            type="submit"
+            class="group relative flex w-full justify-center rounded-md border border-transparent bg-gray-400 py-2 px-4 text-sm font-medium text-white hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            登入
+          </button>
+        </div>
+      </form>
+      <div class="relative">
+        <div
+          class="absolute inset-0 flex items-center"
+          aria-hidden="true"
+        >
+          <div class="w-full border-t border-gray-300" />
+        </div>
+        <div class="relative flex justify-center text-sm">
+          <span class="bg-gray-50 px-2 text-gray-500">或使用其他方式登入</span>
+        </div>
+      </div>
+      <div>
+        <button
+          type="button"
+          class="group relative flex w-full justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          使用 Google 帳戶登入
+        </button>
+      </div>
+      <div class="text-center text-sm">
+        還沒有帳戶？
+        <a href="#">立即註冊</a>
+      </div>
+    </div>
+  </div>
 </template>

--- a/project-steps.md
+++ b/project-steps.md
@@ -252,3 +252,14 @@
 - **路由實踐釐清**: 針對 `layouts/user.vue` 中的「登入/註冊」連結，深入討論了 `<NuxtLink>` 的兩種 `to` 屬性寫法。
 - **最佳實踐採納**: 確認並建議採用「命名路由物件寫法」 (`:to="{ name: 'routeName' }"`) 取代「硬編碼 URL 字串」 (`to="/path/to/page"`)。
 - **理由與優勢**: 此舉能將連結與實際 URL 路徑解耦，大幅提升程式碼的健壯性與長期可維護性，未來修改路由時僅需調整路由定義檔，無需搜尋並取代所有相關連結。
+
+### UP1: 體驗者登入頁面 (UI 切版)
+- **UI 切版與策略**:
+  - 根據設計稿，在 `pages/users/login.vue` 中使用 Tailwind CSS 完成了「體驗者登入頁」的 UI 切版。
+  - 釐清並確認了在入口頁面（如登入頁）優先使用原生 HTML 元素與 Tailwind CSS 以達成精準樣式控制，而在功能性強的應用核心頁面則使用 Element Plus 的開發策略。
+- **全域樣式與 CSS Reset**:
+  - 深入探討了 Tailwind CSS 的 Preflight (CSS Reset) 機制，確認其已包含對 `<a>` 標籤的預設樣式重設。
+  - 透過移除 `<a>` 標籤上多餘的功能類別 (utility classes) 並刪除元件內的 `<style scoped>`，成功讓全域的 Preflight 樣式生效，達成了全站連結樣式統一的最佳實踐，避免了引入額外的 `reset.css`。
+- **互動樣式微調**:
+  - 解決了表單輸入框 `focus` 狀態下 `outline` 和 `ring` 的樣式問題。
+  - 使用 `padding` 功能類別調整了輸入框的高度，使其符合設計需求。


### PR DESCRIPTION
### UP1: 體驗者登入頁面 (UI 切版)
- **UI 切版與策略**:
  - 根據設計稿，在 `pages/users/login.vue` 中使用 Tailwind CSS 完成了「體驗者登入頁」的 UI 切版。
  - 釐清並確認了在入口頁面（如登入頁）優先使用原生 HTML 元素與 Tailwind CSS 以達成精準樣式控制，而在功能性強的應用核心頁面則使用 Element Plus 的開發策略。
- **全域樣式與 CSS Reset**:
  - 深入探討了 Tailwind CSS 的 Preflight (CSS Reset) 機制，確認其已包含對 `<a>` 標籤的預設樣式重設。
  - 透過移除 `<a>` 標籤上多餘的功能類別 (utility classes) 並刪除元件內的 `<style scoped>`，成功讓全域的 Preflight 樣式生效，達成了全站連結樣式統一的最佳實踐，避免了引入額外的 `reset.css`。
- **互動樣式微調**:
  - 解決了表單輸入框 `focus` 狀態下 `outline` 和 `ring` 的樣式問題。
  - 使用 `padding` 功能類別調整了輸入框的高度，使其符合設計需求。