### PR TITLE
Feat/up15 UI users comments list

### DIFF
--- a/layouts/user.vue
+++ b/layouts/user.vue
@@ -110,10 +110,10 @@ const socialLinks = ref([
                   <font-awesome-icon :icon="['fas', 'user-circle']" />
                   <span>帳戶中心</span>
                 </a>
-                <a href="#" class="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                <NuxtLink :to="{ name: 'user-comments' }" class="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                   <font-awesome-icon :icon="['fas', 'question-circle']" />
                   <span>評價列表</span>
-                </a>
+                </NuxtLink>
                  <div class="border-t my-1"></div>
                 <a href="#" class="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                   <font-awesome-icon :icon="['fas', 'sign-out-alt']" />
@@ -173,10 +173,10 @@ const socialLinks = ref([
                     <font-awesome-icon :icon="['fas', 'user-circle']" />
                     <span>帳戶中心</span>
                   </a>
-                  <a href="#" class="flex items-center gap-3 px-4 py-2 text-lg text-gray-700 hover:bg-gray-100">
+                  <NuxtLink :to="{ name: 'user-comments' }" class="flex items-center gap-3 px-4 py-2 text-lg text-gray-700 hover:bg-gray-100">
                     <font-awesome-icon :icon="['fas', 'question-circle']" />
                     <span>評價列表</span>
-                  </a>
+                  </NuxtLink>
                    <div class="border-t my-1"></div>
                   <a href="#" class="flex items-center gap-3 px-4 py-2 text-lg text-gray-700 hover:bg-gray-100">
                     <font-awesome-icon :icon="['fas', 'sign-out-alt']" />

--- a/layouts/user.vue
+++ b/layouts/user.vue
@@ -186,12 +186,12 @@ const socialLinks = ref([
 
               <!-- Guest Mobile Menu -->
               <div v-else class="flex flex-col gap-8 lg:hidden">
-                <a href="#" class="px-4 py-2 text-lg text-gray-700 hover:text-blue-600 transition-colors font-medium">
+                <NuxtLink :to="{ name: 'user-login' }" class="px-4 py-2 text-lg text-gray-700 hover:text-blue-600 transition-colors font-medium">
                   登入
-                </a>
-                <a href="#" class="px-4 py-2 text-lg text-gray-700 hover:text-blue-600 transition-colors font-medium">
+                </NuxtLink>
+                <NuxtLink :to="{ name: 'user-register' }" class="px-4 py-2 text-lg text-gray-700 hover:text-blue-600 transition-colors font-medium">
                   註冊
-                </a>
+                </NuxtLink>
               </div>
             </div>
           </div>

--- a/pages/users/comments/[commentId].vue
+++ b/pages/users/comments/[commentId].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 definePageMeta({
-  name: 'userCommentDetail',
+  name: 'user-comments-detail',
+  layout: 'user',
 });
 </script>
 

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -1,11 +1,206 @@
 <script setup lang="ts">
+import { ref } from 'vue';
+
 definePageMeta({
   name: 'user-comments',
   layout: 'user',
 });
+
+// 暫時硬編寫，後續由 API 帶入
+const totalReviews = ref(24);
+// 篩選器狀態（設計圖：審核狀態/日期）
+const statusOptions = ['已通過', '已拒絕', '未評價'];
+const selectedStatuses = ref<string[]>([]);
+
+const dateSortOptions = [
+  { label: '新到舊', value: 'newest' },
+  { label: '舊到新', value: 'oldest' },
+] as const;
+const selectedDateSort = ref<'newest' | 'oldest'>('newest');
+
+function onClearFilters() {
+  selectedStatuses.value = [];
+  selectedDateSort.value = 'newest';
+}
+
+function onApplyFilters() {
+  // 預留：之後串接 API 查詢或觸發列表刷新
+}
+
+// 第二部分：列表假資料
+type ReviewStatus = '未評價' | '已通過' | '已退回' | '已拒絕';
+type ReviewItem = {
+  id: number;
+  companyName: string;
+  programTitle: string;
+  status: ReviewStatus;
+  rating?: number;
+  date?: string;
+  reviewText?: string;
+  rejectionReason?: string;
+  logoUrl?: string;
+};
+
+function tagTypeForStatus(status: ReviewStatus): 'success' | 'warning' | 'danger' | 'info' {
+  switch (status) {
+    case '已通過':
+      return 'success';
+    case '已退回':
+      return 'warning';
+    case '已拒絕':
+      return 'danger';
+    default:
+      return 'info';
+  }
+}
+
+const reviews = ref<ReviewItem[]>([
+  {
+    id: 1,
+    companyName: 'AVC科技公司',
+    programTitle: '行銷企業體驗',
+    status: '未評價',
+  },
+  {
+    id: 2,
+    companyName: 'AVC科技公司',
+    programTitle: '行銷企業體驗',
+    status: '已通過',
+    rating: 5,
+    date: '2025/10/15',
+    reviewText:
+      '這次的行銷企劃體驗非常棒！我學到了很多實用的技能，也獲得了許多寶貴的建議。整體來說對我的職涯規劃有很大幫助！',
+  },
+  {
+    id: 3,
+    companyName: 'AVC科技公司',
+    programTitle: '行銷企業體驗',
+    status: '已通過',
+    rating: 5,
+    date: '2025/10/15',
+    reviewText:
+      '教練的指導細膩且非常實用，讓我了解產業工作如何應用數據分析工具，並能更深入學習一些實務技巧。',
+  },
+  {
+    id: 4,
+    companyName: 'AVC科技公司',
+    programTitle: '行銷企業體驗',
+    status: '已退回',
+    rating: 5,
+    date: '2025/10/15',
+    reviewText:
+      '人力資源與產品體驗環節貼合度高，整體流程順暢，對於職場的實務內容有更深理解。',
+    rejectionReason:
+      '內容含有不雅字眼，已由系統自動拒絕，將會由人工於 24 小時內複審。',
+  },
+  {
+    id: 5,
+    companyName: 'AVC科技公司',
+    programTitle: '行銷企業體驗',
+    status: '已通過',
+    rating: 5,
+    date: '2025/10/15',
+    reviewText:
+      '財務分析的實作案例很紮實，了解了從資料分析到實際工作流程的連結，幫助很大。',
+  },
+]);
 </script>
 
 <!-- up15 評價列表 -->
 <template>
-  <h1 class="text-3xl font-bold underline">up15 評價列表</h1>
+  <section class="mx-auto max-w-container-main px-6 md:px-12 py-8 md:py-10">
+    <!-- Header: 標題與總數 -->
+    <div class="flex items-end justify-between">
+      <h2 class="text-2xl md:text-3xl font-bold text-gray-800">評價列表</h2>
+      <div class="text-gray-500 text-base md:text-lg">共 {{ totalReviews }} 則評價</div>
+    </div>
+
+    <!-- Controls: 三顆按鈕（Element Plus 預設樣式） -->
+    <div class="mt-6 flex flex-wrap items-center gap-4 md:gap-6">
+      <!-- 篩選 Popover -->
+      <el-popover placement="bottom-start" trigger="click" :width="440">
+        <template #reference>
+          <el-button>篩選</el-button>
+        </template>
+
+        <div class="p-3">
+          <div class="flex flex-col gap-6">
+            <!-- 審核狀態群組 -->
+            <div>
+              <el-tag effect="plain" type="info">審核狀態</el-tag>
+              <div class="mt-3">
+                <el-checkbox-group v-model="selectedStatuses">
+                  <el-checkbox-button v-for="opt in statusOptions" :key="opt" :label="opt" />
+                </el-checkbox-group>
+              </div>
+            </div>
+
+            <!-- 日期排序群組 -->
+            <div>
+              <el-tag effect="plain" type="info">日期</el-tag>
+              <div class="mt-3">
+                <el-radio-group v-model="selectedDateSort">
+                  <el-radio-button v-for="opt in dateSortOptions" :key="opt.value" :label="opt.value">{{ opt.label }}</el-radio-button>
+                </el-radio-group>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 flex justify-end gap-2">
+            <el-button text @click="onClearFilters">清除</el-button>
+            <el-button type="primary" @click="onApplyFilters">套用</el-button>
+          </div>
+        </div>
+      </el-popover>
+    </div>
+
+    <!-- 分隔線 -->
+    <el-divider/>
+
+    <!-- List: 公司評價卡片 -->
+    <div>
+      <div v-for="item in reviews" :key="item.id" class="py-4">
+        <div class="flex items-center justify-between">
+          <!-- Left: Logo + 公司名稱 + 體驗標籤 + 狀態 -->
+          <div class="flex items-center gap-4">
+            <el-avatar :size="48">企業logo</el-avatar>
+            <div class="flex items-center flex-wrap gap-x-3 gap-y-2">
+              <div class="text-lg font-semibold text-gray-800">{{ item.companyName }}</div>
+              <el-tag effect="plain" round>{{ item.programTitle }}</el-tag>
+              <span v-if="item.status === '未評價'" class="text-gray-400">未評價</span>
+              <el-tag v-else :type="tagTypeForStatus(item.status)" size="small" effect="plain">{{ item.status }}</el-tag>
+            </div>
+          </div>
+
+          <!-- Right: 撰寫評價（僅未評價） -->
+          <div v-if="item.status === '未評價'">
+            <el-button size="small" round>撰寫評價</el-button>
+          </div>
+        </div>
+
+        <!-- 評分/日期/狀態列（已送出狀態） -->
+        <div v-if="item.status !== '未評價'" class="mt-3 flex items-center gap-4 text-gray-600">
+          <el-rate :model-value="item.rating || 0" disabled />
+          <span class="font-semibold">{{ (item.rating ?? 0).toFixed(1) }}</span>
+          <span class="text-gray-400">{{ item.date }}</span>
+          <el-tag :type="tagTypeForStatus(item.status)" size="small" effect="plain">{{ item.status }}</el-tag>
+        </div>
+
+        <!-- 內文 -->
+        <p v-if="item.reviewText" class="mt-2 text-gray-700 leading-relaxed">{{ item.reviewText }}</p>
+
+        <!-- 退回/拒絕理由 -->
+        <div v-if="item.rejectionReason" class="mt-3 text-gray-600">
+          <span class="text-gray-500">拒絕理由：</span>
+          <span>{{ item.rejectionReason }}</span>
+          <div class="mt-2 text-right">
+            <el-button size="small" round plain type="info">修改再傳</el-button>
+          </div>
+        </div>
+
+        <!-- item divider -->
+        <el-divider />
+      </div>
+    </div>
+  </section>
 </template>

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -104,6 +104,10 @@ const reviews = ref<ReviewItem[]>([
       '財務分析的實作案例很紮實，了解了從資料分析到實際工作流程的連結，幫助很大。',
   },
 ]);
+
+function onWriteReview(commentId: number) {
+  navigateTo({ name: 'user-comments-detail', params: { commentId: String(commentId) } });
+}
 </script>
 
 <!-- up15 評價列表 -->
@@ -174,7 +178,7 @@ const reviews = ref<ReviewItem[]>([
 
           <!-- Right: 撰寫評價（僅未評價） -->
           <div v-if="item.status === '未評價'">
-            <el-button size="small" round>撰寫評價</el-button>
+            <el-button size="small" round @click="onWriteReview(item.id)">撰寫評價</el-button>
           </div>
         </div>
 
@@ -190,11 +194,11 @@ const reviews = ref<ReviewItem[]>([
         <p v-if="item.reviewText" class="mt-2 text-gray-700 leading-relaxed">{{ item.reviewText }}</p>
 
         <!-- 退回/拒絕理由 -->
-        <div v-if="item.rejectionReason" class="mt-3 text-gray-600">
+          <div v-if="item.rejectionReason" class="mt-3 text-gray-600">
           <span class="text-gray-500">拒絕理由：</span>
           <span>{{ item.rejectionReason }}</span>
           <div class="mt-2 text-right">
-            <el-button size="small" round plain type="info">修改再傳</el-button>
+            <el-button size="small" round plain type="info" @click="onWriteReview(item.id)">修改再傳</el-button>
           </div>
         </div>
 

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 definePageMeta({
   name: 'user-comments',
+  layout: 'user',
 });
 </script>
 

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 definePageMeta({
-  name: 'userComments',
+  name: 'user-comments',
 });
 </script>
 

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -27,6 +27,7 @@ function onClearFilters() {
 function onApplyFilters() {
   // 預留：之後串接 API 查詢或觸發列表刷新
   currentPage.value = 1;
+  filterVisible.value = false; // 套用後關閉篩選面板
 }
 
 // 第二部分：列表假資料
@@ -129,6 +130,9 @@ const visibleReviews = computed<ReviewItem[]>(() => {
   const start = (currentPage.value - 1) * pageSize.value;
   return allReviews.value.slice(start, start + pageSize.value);
 });
+
+// 篩選面板可見性（受控）
+const filterVisible = ref(false);
 </script>
 
 <!-- up15 評價列表 -->
@@ -143,7 +147,7 @@ const visibleReviews = computed<ReviewItem[]>(() => {
     <!-- Controls: 三顆按鈕（Element Plus 預設樣式） -->
     <div class="mt-6 flex flex-wrap items-center gap-4 md:gap-6">
       <!-- 篩選 Popover -->
-      <el-popover placement="bottom-start" trigger="click" :width="440">
+      <el-popover v-model:visible="filterVisible" placement="bottom-start" trigger="click" :width="440">
         <template #reference>
           <el-button>篩選</el-button>
         </template>

--- a/project-steps.md
+++ b/project-steps.md
@@ -419,3 +419,10 @@
 - 路由方式：使用 `navigateTo({ name: 'userCommentDetail', params: { commentId } })` 導向 `pages/users/comments/[commentId].vue`。
 - 理由與效果：採命名路由與 SPA 導航，避免整頁刷新並保留列表的篩選/滾動狀態，降低未來路由改動風險。
 - 影響檔案：`pages/users/comments/index.vue`、`pages/users/comments/[commentId].vue`
+
+### UP15: 體驗者評價列表頁（UI 第三部分：分頁器）
+- 分頁器：採用 Element Plus `el-pagination`，版型 `prev, pager, next`，`pager-count=7`，啟用 `background`。
+- 每頁筆數：增加「每頁顯示」下拉 (`el-select`) 提供 10/20/30/50；與列表雙向綁定。
+- 資料分頁：新增 `currentPage`、`pageSize` 狀態與 `visibleReviews` 計算屬性；以 `allReviews` 依 `totalReviews` 擴展假資料以展示效果。
+- 互動行為：在篩選「清除/套用」時自動重置至第 1 頁，避免出現空頁。
+- 影響檔案：`pages/users/comments/index.vue`

--- a/project-steps.md
+++ b/project-steps.md
@@ -413,3 +413,9 @@
 - 將「評價列表」改為 `<NuxtLink :to="{ name: 'user-comments' }"/>`，桌面與行動選單一致。
 - Guest Mobile Menu 的「登入」「註冊」由 `<a>` 改為 `NuxtLink`，分別導向 `user-login` 與 `user-register`；採命名路由以降低路徑耦合並啟用預取。
 - 影響檔案：`layouts/user.vue`
+
+### UP15: 評價列表至詳情頁導航
+- 導航實作：於 `pages/users/comments/index.vue` 為「撰寫評價」與退回情境的「修改再傳」加入點擊事件。
+- 路由方式：使用 `navigateTo({ name: 'userCommentDetail', params: { commentId } })` 導向 `pages/users/comments/[commentId].vue`。
+- 理由與效果：採命名路由與 SPA 導航，避免整頁刷新並保留列表的篩選/滾動狀態，降低未來路由改動風險。
+- 影響檔案：`pages/users/comments/index.vue`、`pages/users/comments/[commentId].vue`

--- a/project-steps.md
+++ b/project-steps.md
@@ -393,3 +393,23 @@
 - 視覺/邊界：修正 Popover 子元素溢出、標籤與群組間距、相鄰 radio 邊框裁切；最小裝置寬 370px 表現正常。
 - 行為：套用後重置至第 1 頁；卡片與表格仍共用同一分頁資料源。
 - 影響檔案：`pages/users/applications/index.vue`
+
+### UP15: 體驗者評價列表頁（UI 第一/二部分與篩選）
+- 頁面與佈局：建立 `pages/users/comments/index.vue`，`definePageMeta` 綁定 `name: 'user-comments'`、`layout: 'user'`，沿用專案版心寬度。
+- 頂部區塊：左側標題「評價列表」、右側統計「共 24 則評價」（暫以假資料）；控制列提供「篩選」按鈕。
+- 篩選 Popover：使用 Element Plus（預設樣式）實作
+  - 狀態多選：已通過／已拒絕／未評價（`el-checkbox-button`）
+  - 日期排序：新到舊／舊到新（`el-radio-button`）
+  - 動作：清除／套用；預留 `onApplyFilters/onClearFilters` 供後續串 API。
+- 列表卡片（第二部分）：
+  - 左：`Avatar` + 公司名 + 體驗標籤 + 狀態標籤（`tagTypeForStatus` 對應 success/warning/danger/info）
+  - 右（僅未評價）：「撰寫評價」按鈕
+  - 已送出：顯示星等（`el-rate` disabled）、分數、日期、狀態標籤；支援內文與退回/拒絕理由（含「修改再傳」按鈕）
+- 型別與資料：定義 `ReviewStatus`、`ReviewItem`，以假資料渲染多種情境；保留最小 Tailwind 作間距排版。
+- 其他：釐清 `!` 前綴僅為覆蓋間距用途；本頁改回使用 `el-divider` 預設間距；Lint 通過。
+- 影響檔案：`pages/users/comments/index.vue`
+
+### Layout: 體驗者佈局 - 評價列表與訪客導航
+- 將「評價列表」改為 `<NuxtLink :to="{ name: 'user-comments' }"/>`，桌面與行動選單一致。
+- Guest Mobile Menu 的「登入」「註冊」由 `<a>` 改為 `NuxtLink`，分別導向 `user-login` 與 `user-register`；採命名路由以降低路徑耦合並啟用預取。
+- 影響檔案：`layouts/user.vue`


### PR DESCRIPTION
### UP15: 體驗者評價列表頁（UI 第一/二部分與篩選）
- 頁面與佈局：建立 `pages/users/comments/index.vue`，`definePageMeta` 綁定 `name: 'user-comments'`、`layout: 'user'`，沿用專案版心寬度。
- 頂部區塊：左側標題「評價列表」、右側統計「共 24 則評價」（暫以假資料）；控制列提供「篩選」按鈕。
- 篩選 Popover：使用 Element Plus（預設樣式）實作
  - 狀態多選：已通過／已拒絕／未評價（`el-checkbox-button`）
  - 日期排序：新到舊／舊到新（`el-radio-button`）
  - 動作：清除／套用；預留 `onApplyFilters/onClearFilters` 供後續串 API。
- 列表卡片（第二部分）：
  - 左：`Avatar` + 公司名 + 體驗標籤 + 狀態標籤（`tagTypeForStatus` 對應 success/warning/danger/info）
  - 右（僅未評價）：「撰寫評價」按鈕
  - 已送出：顯示星等（`el-rate` disabled）、分數、日期、狀態標籤；支援內文與退回/拒絕理由（含「修改再傳」按鈕）
- 型別與資料：定義 `ReviewStatus`、`ReviewItem`，以假資料渲染多種情境；保留最小 Tailwind 作間距排版。
- 其他：釐清 `!` 前綴僅為覆蓋間距用途；本頁改回使用 `el-divider` 預設間距；Lint 通過。
- 影響檔案：`pages/users/comments/index.vue`

### Layout: 體驗者佈局 - 評價列表與訪客導航
- 將「評價列表」改為 `<NuxtLink :to="{ name: 'user-comments' }"/>`，桌面與行動選單一致。
- Guest Mobile Menu 的「登入」「註冊」由 `<a>` 改為 `NuxtLink`，分別導向 `user-login` 與 `user-register`；採命名路由以降低路徑耦合並啟用預取。
- 影響檔案：`layouts/user.vue`

### UP15: 評價列表至詳情頁導航
- 導航實作：於 `pages/users/comments/index.vue` 為「撰寫評價」與退回情境的「修改再傳」加入點擊事件。
- 路由方式：使用 `navigateTo({ name: 'userCommentDetail', params: { commentId } })` 導向 `pages/users/comments/[commentId].vue`。
- 理由與效果：採命名路由與 SPA 導航，避免整頁刷新並保留列表的篩選/滾動狀態，降低未來路由改動風險。
- 影響檔案：`pages/users/comments/index.vue`、`pages/users/comments/[commentId].vue`

### UP15: 體驗者評價列表頁（UI 第三部分：分頁器）
- 分頁器：採用 Element Plus `el-pagination`，版型 `prev, pager, next`，`pager-count=7`，啟用 `background`。
- 每頁筆數：增加「每頁顯示」下拉 (`el-select`) 提供 10/20/30/50；與列表雙向綁定。
- 資料分頁：新增 `currentPage`、`pageSize` 狀態與 `visibleReviews` 計算屬性；以 `allReviews` 依 `totalReviews` 擴展假資料以展示效果。
- 互動行為：在篩選「清除/套用」時自動重置至第 1 頁，避免出現空頁。
- 影響檔案：`pages/users/comments/index.vue`