### PR TITLE
Feat/up7 UI comments fill the form

### DIFF
--- a/pages/company/programs/[programId]/applicants/[applicantId].vue
+++ b/pages/company/programs/[programId]/applicants/[applicantId].vue
@@ -294,10 +294,10 @@ const submitReview = async () => {
         <el-form :model="decisionForm" label-position="top">
           <el-form-item label="審核結果">
             <el-radio-group v-model="decisionForm.status">
-              <el-radio label="pending">
+              <el-radio :value="'pending'">
                 核准申請
               </el-radio>
-              <el-radio label="rejected">
+              <el-radio :value="'rejected'">
                 婉拒申請
               </el-radio>
             </el-radio-group>

--- a/pages/users/comments/[commentId].vue
+++ b/pages/users/comments/[commentId].vue
@@ -1,11 +1,134 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { FormInstance, FormRules } from 'element-plus';
+import { ElMessage } from 'element-plus';
+
 definePageMeta({
   name: 'user-comments-detail',
   layout: 'user',
 });
+
+const route = useRoute();
+const commentId = computed(() => String(route.params.commentId ?? ''));
+
+const MAX_LENGTH = 1000;
+
+type ReviewForm = {
+  rating: number;
+  content: string;
+  agree: boolean;
+};
+
+const formRef = ref<FormInstance>();
+const form = ref<ReviewForm>({
+  rating: 0,
+  content: '',
+  agree: false,
+});
+
+const rules: FormRules<ReviewForm> = {
+  rating: [
+    { type: 'number', required: true, message: '請給予整體評分', trigger: 'change' },
+  ],
+  content: [
+    { required: true, message: '請輸入評價內容', trigger: ['blur', 'change'] },
+    {
+      validator: (_r, value: string, callback) => {
+        if (typeof value !== 'string') return callback(new Error('內容格式不正確'));
+        if (value.length > MAX_LENGTH) return callback(new Error(`字數請在 ${MAX_LENGTH} 字以內`));
+        callback();
+      },
+      trigger: ['blur', 'change'],
+    },
+  ],
+  agree: [
+    {
+      validator: (_r, value: boolean, callback) => {
+        if (!value) return callback(new Error('請勾選同意聲明'));
+        callback();
+      },
+      trigger: 'change',
+    },
+  ],
+};
+
+const ratingDisplay = computed(() => (form.value.rating || 0).toFixed(1));
+const contentCount = computed(() => form.value.content.length);
+const canSubmit = computed(() => form.value.rating > 0 && form.value.content.length > 0 && form.value.content.length <= MAX_LENGTH && form.value.agree);
+
+function handleCancel(): void {
+  navigateTo({ name: 'user-comments' });
+}
+
+async function handleSubmit(): Promise<void> {
+  const valid = await formRef.value?.validate().catch(() => false);
+  if (!valid) return;
+
+  // 預留：提交 API
+  ElMessage.success('已送出評價');
+  navigateTo({ name: 'user-comments' });
+}
+
+// 假資料：公司與體驗資訊（後續由 API 帶入）
+const companyName = '台灣數位科技公司';
+const programTitle = '數據分析師體驗計畫';
+const periodText = '體驗期間：2025/09/15 - 2025/10/15';
 </script>
 
 <!-- up7 填寫評價頁面 -->
 <template>
-  <h1 class="text-3xl font-bold underline">up7 填寫評價頁面</h1>
+  <section class="mx-auto max-w-container-main px-6 md:px-12 py-8 md:py-10">
+    <h2 class="text-2xl md:text-3xl font-bold text-gray-800">撰寫體驗評價</h2>
+
+    <!-- 體驗資訊卡片 -->
+    <el-card class="mt-6">
+      <div class="flex flex-col gap-2">
+        <div class="text-gray-700 font-semibold">{{ companyName }}</div>
+        <div class="flex items-center justify-between text-gray-600">
+          <div>{{ programTitle }}</div>
+          <div class="text-sm">{{ periodText }}</div>
+        </div>
+      </div>
+    </el-card>
+
+    <el-divider class="!my-6" />
+
+    <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
+      <!-- 整體評分 -->
+      <el-form-item label="整體評分" prop="rating">
+        <div class="flex items-center gap-3">
+          <el-rate v-model="form.rating" allow-half />
+          <span class="text-gray-600 font-semibold">{{ ratingDisplay }}</span>
+        </div>
+      </el-form-item>
+
+      <!-- 評論內容 -->
+      <el-form-item label="評論內容" prop="content">
+        <div class="w-full">
+          <el-input
+            v-model="form.content"
+            type="textarea"
+            :rows="6"
+            :maxlength="MAX_LENGTH"
+            show-word-limit
+            :placeholder="`請分享您的體驗心得，例如：\n你學到什麼？\n你是否覺得這次體驗的哪一個部分是有幫助的？\n你願意推薦這家公司給下一位體驗探索者嗎？為什麼？`"
+          />
+          <div class="mt-2 text-sm text-gray-500">已輸入 {{ contentCount }} / {{ MAX_LENGTH }}</div>
+        </div>
+      </el-form-item>
+
+      <!-- 同意條款 -->
+      <el-form-item prop="agree">
+        <el-checkbox v-model="form.agree">
+          我同意此評價將於公開顯示在平台上，且確認內容真實無誤
+        </el-checkbox>
+      </el-form-item>
+
+      <!-- 動作按鈕 -->
+      <div class="mt-4 flex justify-end gap-3">
+        <el-button @click="handleCancel">取消</el-button>
+        <el-button type="primary" :disabled="!canSubmit" @click="handleSubmit">送出</el-button>
+      </div>
+    </el-form>
+  </section>
 </template>

--- a/pages/users/comments/[commentId].vue
+++ b/pages/users/comments/[commentId].vue
@@ -77,7 +77,7 @@ const periodText = '體驗期間：2025/09/15 - 2025/10/15';
 
 <!-- up7 填寫評價頁面 -->
 <template>
-  <section class="mx-auto max-w-container-main px-6 md:px-12 py-8 md:py-10">
+  <section class="mx-auto max-w-container-users px-6 md:px-12 py-8 md:py-10">
     <h2 class="text-2xl md:text-3xl font-bold text-gray-800">撰寫體驗評價</h2>
 
     <!-- 體驗資訊卡片 -->

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -159,7 +159,7 @@ const filterVisible = ref(false);
               <el-tag effect="plain" type="info">審核狀態</el-tag>
               <div class="mt-3">
                 <el-checkbox-group v-model="selectedStatuses">
-                  <el-checkbox-button v-for="opt in statusOptions" :key="opt" :label="opt" />
+                  <el-checkbox-button v-for="opt in statusOptions" :key="opt" :value="opt">{{ opt }}</el-checkbox-button>
                 </el-checkbox-group>
               </div>
             </div>
@@ -169,7 +169,7 @@ const filterVisible = ref(false);
               <el-tag effect="plain" type="info">日期</el-tag>
               <div class="mt-3">
                 <el-radio-group v-model="selectedDateSort">
-                  <el-radio-button v-for="opt in dateSortOptions" :key="opt.value" :label="opt.value">{{ opt.label }}</el-radio-button>
+                  <el-radio-button v-for="opt in dateSortOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</el-radio-button>
                 </el-radio-group>
               </div>
             </div>

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -109,7 +109,7 @@ const reviews = ref<ReviewItem[]>([
 ]);
 
 function onWriteReview(commentId: number) {
-  navigateTo({ name: 'userCommentDetail', params: { commentId: String(commentId) } });
+  navigateTo({ name: 'user-comments-detail', params: { commentId: String(commentId) } });
 }
 
 // --- Pagination 狀態 ---

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -137,7 +137,7 @@ const filterVisible = ref(false);
 
 <!-- up15 評價列表 -->
 <template>
-  <section class="mx-auto max-w-container-main px-6 md:px-12 py-8 md:py-10">
+  <section class="mx-auto max-w-container-users px-6 md:px-12 py-8 md:py-10">
     <!-- Header: 標題與總數 -->
     <div class="flex items-end justify-between">
       <h2 class="text-2xl md:text-3xl font-bold text-gray-800">評價列表</h2>

--- a/project-steps.md
+++ b/project-steps.md
@@ -426,3 +426,20 @@
 - 資料分頁：新增 `currentPage`、`pageSize` 狀態與 `visibleReviews` 計算屬性；以 `allReviews` 依 `totalReviews` 擴展假資料以展示效果。
 - 互動行為：在篩選「清除/套用」時自動重置至第 1 頁，避免出現空頁。
 - 影響檔案：`pages/users/comments/index.vue`
+
+### UP7: 體驗者評價填寫頁（UI + 基本驗證）
+- 頁面與路由：建立 `pages/users/comments/[commentId].vue`，綁定 `definePageMeta({ name: 'user-comments-detail', layout: 'user' })`。
+- 表單與互動：以 Element Plus 實作整體評分、評論內容（上限 1000 字 + 計數）、同意勾選、取消與送出；加入規則驗證與可送出條件；送出成功以訊息提示並導回 `user-comments`。
+- 體驗資訊卡：顯示公司名稱、計畫標題、體驗期間（暫以假資料，預留 `useFetch` 串接）。
+- 視覺：暫採容器滿寬（移除 `max-w-4xl`），後續視需求再調整。
+- 影響檔案：`pages/users/comments/[commentId].vue`
+
+### ROUTE: 評價詳情命名路由修正
+- 決策：統一使用 kebab-case `user-comments-detail`；同步更新列表頁導向，消除命名不一致風險。
+- 理由：符合專案命名策略並避免導頁失敗。
+- 影響檔案：`pages/users/comments/index.vue`、`pages/users/comments/[commentId].vue`
+
+### TECH: Element Plus 棄用 API 警告排除（label act as value）
+- 調整：將 `el-checkbox-button`、`el-radio-button`、`el-radio` 的 `label` 充當值寫法改為 `value` 綁定，並以插槽呈現文字，移除控制台警告。
+- 影響檔案：`pages/users/comments/index.vue`、`pages/company/programs/[programId]/applicants/[applicantId].vue`
+- 參考文件：Element Plus Checkbox（`https://element-plus.org/en-US/component/checkbox.html`）


### PR DESCRIPTION
### UP7: 體驗者評價填寫頁（UI + 基本驗證）
- 頁面與路由：建立 `pages/users/comments/[commentId].vue`，綁定 `definePageMeta({ name: 'user-comments-detail', layout: 'user' })`。
- 表單與互動：以 Element Plus 實作整體評分、評論內容（上限 1000 字 + 計數）、同意勾選、取消與送出；加入規則驗證與可送出條件；送出成功以訊息提示並導回 `user-comments`。
- 體驗資訊卡：顯示公司名稱、計畫標題、體驗期間（暫以假資料，預留 `useFetch` 串接）。
- 視覺：暫採容器滿寬（移除 `max-w-4xl`），後續視需求再調整。
- 影響檔案：`pages/users/comments/[commentId].vue`

### ROUTE: 評價詳情命名路由修正
- 決策：統一使用 kebab-case `user-comments-detail`；同步更新列表頁導向，消除命名不一致風險。
- 理由：符合專案命名策略並避免導頁失敗。
- 影響檔案：`pages/users/comments/index.vue`、`pages/users/comments/[commentId].vue`

### TECH: Element Plus 棄用 API 警告排除（label act as value）
- 調整：將 `el-checkbox-button`、`el-radio-button`、`el-radio` 的 `label` 充當值寫法改為 `value` 綁定，並以插槽呈現文字，移除控制台警告。
- 影響檔案：`pages/users/comments/index.vue`、`pages/company/programs/[programId]/applicants/[applicantId].vue`
- 參考文件：Element Plus Checkbox（`https://element-plus.org/en-US/component/checkbox.html`）