### PR TITLE
Feat/pp1 UI admin login

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,0 +1,68 @@
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const isSidebarOpen = ref(false)
+const activeIndex = ref(0)
+const navItems = [
+  { key: 'dashboard', label: '儀表板' },
+  { key: 'programs', label: '體驗計畫' },
+  { key: 'popular', label: '熱門體驗' },
+  { key: 'reviews', label: '評價管理' },
+  { key: 'logout', label: '登出' },
+]
+</script>
+
+
+<template>
+  <div class="min-h-screen w-full bg-white text-gray-900">
+    <!-- Top bar -->
+    <header class="flex h-16 w-full items-center justify-between bg-gray-700 px-4 text-white md:px-8">
+      <div class="flex items-center gap-3">
+        <div class="flex h-8 w-12 items-center justify-center rounded bg-gray-600 text-[10px]">LOGO</div>
+        <span class="text-lg font-semibold md:text-xl">TRYβ管理後台系統</span>
+      </div>
+      <div class="flex items-center gap-3">
+        <button class="md:hidden" @click="isSidebarOpen = !isSidebarOpen" aria-label="切換選單">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          </svg>
+        </button>
+        <div class="hidden items-center gap-2 md:flex">
+          <div class="flex h-9 w-9 items-center justify-center rounded-full bg-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-5 w-5">
+              <path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM5.25 20.1a7.5 7.5 0 0113.5 0 .9.9 0 01-.9.9H6.15a.9.9 0 01-.9-.9z" clip-rule="evenodd" />
+            </svg>
+          </div>
+          <span>管理員</span>
+        </div>
+      </div>
+    </header>
+
+    <div class="flex">
+      <!-- Sidebar -->
+      <aside
+        class="fixed inset-y-16 left-0 z-30 w-64 translate-x-0 border-r border-gray-200 bg-white pt-6 transition-transform md:static md:inset-auto md:translate-x-0"
+        :class="{ '-translate-x-full': !isSidebarOpen, 'md:translate-x-0': true }"
+      >
+        <nav class="space-y-6 px-6">
+          <button
+            v-for="(item, idx) in navItems"
+            :key="item.key"
+            class="flex w-full items-center justify-between rounded px-2 py-2 text-left text-gray-800 hover:bg-brand-gray"
+          >
+            <span class="flex items-center gap-3">
+              <span class="block h-5 w-1 rounded bg-gray-400" v-if="idx === activeIndex"></span>
+              <span>{{ item.label }}</span>
+            </span>
+          </button>
+        </nav>
+      </aside>
+
+      <!-- Content -->
+      <main class="ml-0 flex min-h-[calc(100vh-4rem)] w-full flex-col p-4 md:ml-64 md:p-8">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,5 +1,102 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'blank' as any })
+
+import { ref } from 'vue'
+
+const username = ref('')
+const password = ref('')
+const rememberMe = ref(false)
+const showPassword = ref(false)
+</script>
+
+
 <template>
-  <div>
-    <h1>Admin</h1>
+  <div class="min-h-screen bg-white">
+    <div class="mx-auto flex justify-center min-h-screen w-full max-w-container-admin">
+      <!-- Left visual area -->
+      <!-- <div class="hidden w-1/2 bg-brand-gray md:block"></div> -->
+
+      <!-- Right form area -->
+      <div class="flex w-full flex-col  md:w-1/2">
+        <div class="flex flex-1 flex-col items-center justify-center px-6 py-10 md:px-12">
+          <!-- Brand -->
+          <div class="mb-8 flex items-center gap-3">
+            <div class="flex h-8 w-12 items-center justify-center rounded border border-gray-300 text-[10px] text-gray-500">
+              LOGO
+            </div>
+            <h1 class="text-xl font-semibold text-gray-800 md:text-2xl">TRYβ管理後台系統</h1>
+          </div>
+
+          <h2 class="mb-6 text-lg font-semibold text-gray-900 md:mb-8 md:text-xl">管理員登入</h2>
+
+          <!-- Login form -->
+          <form class="w-full max-w-md" @submit.prevent>
+            <div class="mb-4">
+              <label for="admin-username" class="mb-2 block text-sm text-gray-700">帳號</label>
+              <input
+                id="admin-username"
+                v-model="username"
+                type="text"
+                inputmode="email"
+                autocomplete="username"
+                placeholder="請輸入您的帳號"
+                class="w-full rounded border border-gray-300 px-4 py-3 text-gray-900 placeholder-gray-400 outline-none focus:border-primary-blue focus:ring-1 focus:ring-primary-blue"
+              />
+            </div>
+
+            <div class="mb-4">
+              <label for="admin-password" class="mb-2 block text-sm text-gray-700">密碼</label>
+              <input
+                id="admin-password"
+                v-model="password"
+                :type="showPassword ? 'text' : 'password'"
+                autocomplete="current-password"
+                placeholder="請輸入您的密碼"
+                class="w-full rounded border border-gray-300 px-4 py-3 text-gray-900 placeholder-gray-400 outline-none focus:border-primary-blue focus:ring-1 focus:ring-primary-blue"
+              />
+            </div>
+
+            <div class="mb-6 flex items-center justify-between text-sm">
+              <label class="inline-flex items-center gap-2 text-gray-700">
+                <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-primary-blue focus:ring-primary-blue" />
+                記住我的帳號
+              </label>
+              <a href="#" class="text-gray-500 hover:text-gray-700">忘記密碼?</a>
+            </div>
+
+            <button
+              type="submit"
+              class="w-full rounded bg-gray-700 px-4 py-3 text-white transition-colors hover:bg-gray-800"
+            >
+              登入系統
+            </button>
+          </form>
+
+          <!-- Help link -->
+          <div class="mt-6 text-center text-sm text-gray-600 md:mt-8">
+            遇到問題？
+            <a href="#" class="font-medium text-gray-700 hover:text-primary-blue">聯絡系統管理員</a>
+          </div>
+
+          <div class="mt-8 w-full max-w-md border-t border-gray-200 md:mt-10"></div>
+
+          <!-- Footer -->
+          <div class="mt-4 text-center text-xs leading-6 text-gray-500">
+            © 2025 管理後台系統. 版權所有。<br />
+            使用本系統代表您同意我們的
+            <a href="#" class="underline hover:text-gray-700">使用條款</a>
+            和
+            <a href="#" class="underline hover:text-gray-700">隱私政策</a>
+          </div>
+        </div>
+
+        <!-- Optional slot area (not used by login, reserved for future pages) -->
+        <div class="px-6 pb-10 md:px-12">
+          <slot />
+        </div>
+      </div>
+    </div>
   </div>
+  
 </template>
+

--- a/project-steps.md
+++ b/project-steps.md
@@ -464,6 +464,7 @@
 - 版心與樣式：沿用 `max-w-container-users`，以 Element Plus 預設樣式為主、少量 Tailwind 做間距與排版。
 - 影響檔案：`pages/users/favorites/index.vue`
 
+
 ### Layout: 體驗者佈局—收藏清單導航
 - 導航更新：將 `layouts/user.vue` 內桌面與行動版「收藏清單」連結改為命名路由 `<NuxtLink :to="{ name: 'user-favorites' }"/>`，與「申請清單」「評價列表」一致。
 - 理由：以命名路由降低壞鏈風險並支援 prefetch，維持桌/行動一致的 UX。
@@ -474,3 +475,15 @@
 - 狀態管理：`currentPage/pageSize/visibleItems/total`，以計算屬性切片顯示當前頁資料。
 - 假資料：擴充為 8 筆以驗證分頁行為；清空收藏時改為空陣列以呈現 `ElEmpty`。
 - 影響檔案：`pages/users/favorites/index.vue`
+
+# 2025-08-12
+### ADMIN: 後台佈局（基礎框架）
+- 建立 `layouts/admin.vue` 依設計稿完成：深色頂欄（LOGO＋系統名稱＋使用者區塊、行動裝置含側欄切換）與左側側欄選單（儀表板／體驗計畫／熱門體驗／評價管理／登出）。
+- 內容區以 `<slot>` 注入，確保後台頁面可重用同一框架；RWD：手機側欄可收合，桌面固定側欄；對齊專案版心與色票（`max-w-container-admin`、`brand-gray`）。
+- 技術細節：純 Tailwind 實作，未新增依賴；狀態以 `ref` 管理（`isSidebarOpen`、`activeIndex`）；Lint 通過。
+
+### PP1: 管理員登入頁（UI 切版與佈局分離）
+- `pages/admin/index.vue` 定義為「pp1 管理員登入頁」，內容含 LOGO 與標題、帳號/密碼欄位、記住我、忘記密碼、登入按鈕；下方提供「聯絡系統管理員」與版權資訊的極簡頁尾。
+- 佈局策略：明確設定 `definePageMeta({ layout: 'blank' })`，使登入頁不載入後台導覽，保持獨立與專注。
+- 設計原則：Admin 僅供內部使用，不放置「首頁／方案／聯絡我們」等行銷導覽；保留必要支援與法務文案。
+- RWD 與樣式：裝置寬度下限 370px；採用 `md` 斷點；沿用 Tailwind 既有色票與表單 focus 樣式；Lint 通過。


### PR DESCRIPTION
# 2025-08-12
### ADMIN: 後台佈局（基礎框架）
- 建立 `layouts/admin.vue` 依設計稿完成：深色頂欄（LOGO＋系統名稱＋使用者區塊、行動裝置含側欄切換）與左側側欄選單（儀表板／體驗計畫／熱門體驗／評價管理／登出）。
- 內容區以 `<slot>` 注入，確保後台頁面可重用同一框架；RWD：手機側欄可收合，桌面固定側欄；對齊專案版心與色票（`max-w-container-admin`、`brand-gray`）。
- 技術細節：純 Tailwind 實作，未新增依賴；狀態以 `ref` 管理（`isSidebarOpen`、`activeIndex`）；Lint 通過。

### PP1: 管理員登入頁（UI 切版與佈局分離）
- `pages/admin/index.vue` 定義為「pp1 管理員登入頁」，內容含 LOGO 與標題、帳號/密碼欄位、記住我、忘記密碼、登入按鈕；下方提供「聯絡系統管理員」與版權資訊的極簡頁尾。
- 佈局策略：明確設定 `definePageMeta({ layout: 'blank' })`，使登入頁不載入後台導覽，保持獨立與專注。
- 設計原則：Admin 僅供內部使用，不放置「首頁／方案／聯絡我們」等行銷導覽；保留必要支援與法務文案。
- RWD 與樣式：裝置寬度下限 370px；採用 `md` 斷點；沿用 Tailwind 既有色票與表單 focus 樣式；Lint 通過。