### PR TITLE
feat(users): 套用全域表單寬度 token 至 users 工具列/篩選

### DIFF
--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -237,7 +237,7 @@ const filterVisible = ref(false);
       <!-- 每頁顯示 -->
       <div class="flex items-center gap-3">
         <span class="text-gray-600">每頁顯示：</span>
-        <el-select v-model="pageSize" style="width: 120px">
+        <el-select v-model="pageSize" class="w-full min-w-form-control md:max-w-form-select">
           <el-option v-for="size in pageSizeOptions" :key="size" :label="`${size} 筆`" :value="size" />
         </el-select>
       </div>

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -152,17 +152,17 @@ const sortOptions = ref([
 
           <!-- Filters -->
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 mb-8 p-4 bg-white rounded-lg shadow">
-            <el-input v-model="searchKeyword" placeholder="關鍵字搜尋" clearable />
-            <el-select v-model="industry" placeholder="產業類別" clearable>
+            <el-input v-model="searchKeyword" placeholder="關鍵字搜尋" clearable class="w-full md:max-w-form-search" />
+            <el-select v-model="industry" placeholder="產業類別" clearable class="w-full min-w-form-control md:max-w-form-select">
               <el-option v-for="item in industries" :key="item.value" :label="item.label" :value="item.value" />
             </el-select>
-            <el-select v-model="jobType" placeholder="職業類別" clearable>
+            <el-select v-model="jobType" placeholder="職業類別" clearable class="w-full min-w-form-control md:max-w-form-select">
               <el-option v-for="item in jobTypes" :key="item.value" :label="item.label" :value="item.value" />
             </el-select>
-            <el-select v-model="location" placeholder="地區" clearable>
+            <el-select v-model="location" placeholder="地區" clearable class="w-full min-w-form-control md:max-w-form-select">
               <el-option v-for="item in locations" :key="item.value" :label="item.label" :value="item.value" />
             </el-select>
-            <el-select v-model="sort" placeholder="排序" clearable>
+            <el-select v-model="sort" placeholder="排序" clearable class="w-full min-w-form-control md:max-w-form-select">
               <el-option v-for="item in sortOptions" :key="item.value" :label="item.label" :value="item.value" />
             </el-select>
           </div>


### PR DESCRIPTION
決策
- 僅針對工具列與篩選用途的 el-select、搜尋 el-input 套用 token；表單欄位維持全寬不動。

理由
- 降低一次性影響範圍與風險；移除魔術數字，RWD 在 370px/≥768px 表現一致。

其他補充
- 使用 token：min-w-form-control(120)、md:max-w-form-select(150)、md:max-w-form-search(280)。
- 調整檔案：
  - pages/users/index.vue：搜尋框與四個 el-select。
  - pages/users/comments/index.vue：分頁「每頁顯示」el-select。
  - pages/users/applications/index.vue：僅驗證，不變更。
  - pages/users/favorites/index.vue：僅驗證，不變更。
- Lint 綠燈；小螢幕 w-full，md+ 控制上限，未壓縮表單欄位。