### PR TITLE
Feat/company  apply common style settings

### DIFF
--- a/pages/company/comments/index.vue
+++ b/pages/company/comments/index.vue
@@ -18,7 +18,7 @@
         </div>
         <div>
           <label for="rating" class="block text-sm font-medium text-gray-700 mb-1">評價分數</label>
-          <el-select id="rating" v-model="filters.rating" placeholder="全部分數">
+          <el-select id="rating" v-model="filters.rating" placeholder="全部分數" class="w-full min-w-form-control md:max-w-form-select">
             <el-option label="全部分數" value="all" />
             <el-option label="5 星" value="5" />
             <el-option label="4 星" value="4" />
@@ -30,7 +30,7 @@
         <div>
           <label for="dateSort" class="block text-sm font-medium text-gray-700 mb-1">日期範圍</label>
           <div class="flex items-center gap-2">
-            <el-select id="dateSort" v-model="filters.dateSort">
+            <el-select id="dateSort" v-model="filters.dateSort" class="w-full min-w-form-control md:max-w-form-select">
               <el-option label="日期:新到舊" value="desc" />
               <el-option label="日期:舊到新" value="asc" />
             </el-select>
@@ -84,7 +84,7 @@
       <div class="mt-6 flex justify-between items-center">
         <div>
           <span class="text-sm text-gray-600 mr-2">每頁顯示:</span>
-          <el-select v-model="pagination.pageSize" placeholder="Select" style="width: 100px;">
+          <el-select v-model="pagination.pageSize" placeholder="Select" class="w-full min-w-form-control md:max-w-form-select">
             <el-option label="10 筆" :value="10" />
             <el-option label="20 筆" :value="20" />
             <el-option label="50 筆" :value="50" />

--- a/pages/company/index.vue
+++ b/pages/company/index.vue
@@ -217,16 +217,16 @@ const plans: Plan[] = [
       <!-- Filters -->
       <el-card class="mt-4">
         <div class="flex items-center gap-4">
-          <el-input v-model="searchForm.name" placeholder="搜尋計畫名稱..." :prefix-icon="Search" />
-          <el-select v-model="searchForm.industry" placeholder="產業類別">
+          <el-input v-model="searchForm.name" placeholder="搜尋計畫名稱..." :prefix-icon="Search" class="w-full md:max-w-form-search" />
+          <el-select v-model="searchForm.industry" placeholder="產業類別" class="w-full min-w-form-control md:max-w-form-select">
             <el-option label="資訊科技" value="tech" />
             <el-option label="行銷廣告" value="marketing" />
           </el-select>
-          <el-select v-model="searchForm.job_type" placeholder="職務類別">
+          <el-select v-model="searchForm.job_type" placeholder="職務類別" class="w-full min-w-form-control md:max-w-form-select">
             <el-option label="軟體工程師" value="swe" />
             <el-option label="產品設計師" value="pd" />
           </el-select>
-          <el-select v-model="searchForm.sort" placeholder="排序方式">
+          <el-select v-model="searchForm.sort" placeholder="排序方式" class="w-full min-w-form-control md:max-w-form-select">
             <el-option label="日期：由新到舊" value="date_desc" />
             <el-option label="日期：由舊到新" value="date_asc" />
           </el-select>

--- a/pages/company/programs/[programId]/applicants/index.vue
+++ b/pages/company/programs/[programId]/applicants/index.vue
@@ -132,10 +132,10 @@ const approvedStatus = ref('all')
         <h2 class="card-title">
           待審核申請 (5)
         </h2>
-        <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2">
           <span class="text-sm text-zinc-500 whitespace-nowrap">排序方式：</span>
           <ClientOnly>
-            <el-select v-model="pendingSort" size="small" class="w-36">
+              <el-select v-model="pendingSort" size="small" class="w-full min-w-form-control md:max-w-form-select">
               <el-option label="日期 - 新到舊" value="date-desc" />
               <el-option label="日期 - 舊到新" value="date-asc" />
             </el-select>
@@ -199,7 +199,7 @@ const approvedStatus = ref('all')
           <div class="flex items-center gap-2">
             <span class="text-sm text-zinc-500 whitespace-nowrap">排序方式：</span>
             <ClientOnly>
-              <el-select placeholder="排序方式" v-model="approvedSort" size="small" class="w-36">
+              <el-select placeholder="排序方式" v-model="approvedSort" size="small" class="w-full min-w-form-control md:max-w-form-select">
                 <el-option label="日期 - 新到舊" value="date-desc" />
                 <el-option label="日期 - 舊到新" value="date-asc" />
               </el-select>
@@ -208,7 +208,7 @@ const approvedStatus = ref('all')
           <div class="flex items-center gap-2">
             <span class="text-sm text-zinc-500 whitespace-nowrap">狀態：</span>
             <ClientOnly>
-              <el-select v-model="approvedStatus" size="small" class="w-28">
+              <el-select v-model="approvedStatus" size="small" class="w-full min-w-form-control md:max-w-form-select">
                 <el-option label="全部" value="all" />
                 <el-option label="已通過" value="approved" />
                 <el-option label="已拒絕" value="rejected" />

--- a/pages/company/programs/new.vue
+++ b/pages/company/programs/new.vue
@@ -66,14 +66,14 @@ function addDescriptionField() {
       <el-row :gutter="20">
         <el-col :span="12">
           <el-form-item label="產業類別">
-            <el-select v-model="form.industry" placeholder="搜尋計劃名稱" class="w-full">
+            <el-select v-model="form.industry" placeholder="搜尋計劃名稱" class="w-full min-w-form-control md:max-w-form-select">
               <!-- options here -->
             </el-select>
           </el-form-item>
         </el-col>
         <el-col :span="12">
           <el-form-item label="職務類別">
-            <el-select v-model="form.jobCategory" placeholder="請選擇職務類別" class="w-full">
+            <el-select v-model="form.jobCategory" placeholder="請選擇職務類別" class="w-full min-w-form-control md:max-w-form-select">
               <!-- options here -->
             </el-select>
           </el-form-item>
@@ -124,7 +124,7 @@ function addDescriptionField() {
         <el-row :gutter="20" class="w-full">
           <el-col :span="12">
             <el-form-item label="體驗人數">
-              <el-select v-model="form.attendees" class="w-full">
+               <el-select v-model="form.attendees" class="w-full min-w-form-control md:max-w-form-select">
                 <el-option label="1-5 人" value="1-5人" />
               </el-select>
             </el-form-item>
@@ -132,7 +132,7 @@ function addDescriptionField() {
               <el-date-picker v-model="form.startDate" type="date" placeholder="請選擇開始日期" class="w-full" />
             </el-form-item>
             <el-form-item label="刊登期間">
-              <el-select v-model="form.duration" placeholder="請選擇刊登期間" class="w-full">
+              <el-select v-model="form.duration" placeholder="請選擇刊登期間" class="w-full min-w-form-control md:max-w-form-select">
                 <!-- options here -->
               </el-select>
               <p class="text-sm text-gray-500">

--- a/pages/company/settings/index.vue
+++ b/pages/company/settings/index.vue
@@ -71,14 +71,14 @@ const scaleOptions = ['1-50人', '51-100人', '100-200人', '201-500人', '500�
         <el-row :gutter="20">
           <el-col :span="12">
             <el-form-item label="產業類別*">
-              <el-select v-model="companyInfo.industry" class="w-full">
+              <el-select v-model="companyInfo.industry" class="w-full min-w-form-control md:max-w-form-select">
                 <el-option v-for="item in industryOptions" :key="item" :label="item" :value="item" />
               </el-select>
             </el-form-item>
           </el-col>
           <el-col :span="12">
             <el-form-item label="企業規模*">
-              <el-select v-model="companyInfo.scale" class="w-full">
+              <el-select v-model="companyInfo.scale" class="w-full min-w-form-control md:max-w-form-select">
                 <el-option v-for="item in scaleOptions" :key="item" :label="item" :value="item" />
               </el-select>
             </el-form-item>

--- a/project-steps.md
+++ b/project-steps.md
@@ -601,3 +601,22 @@
 - **決策與命名**：採用方案 A；在 `tailwind.config.js` 新增通用最小寬 `minWidth.form-control=120px`，與元件化最大寬 `maxWidth.form-select=150px`、`maxWidth.form-search=280px`。
 - **導入頁面**：將 `pages/admin/comments/index.vue` 內 `el-select`、`el-input(:suffix-icon=Search)` 改為 `min-w-form-control`、`md:max-w-form-select`、`md:max-w-form-search`，統一 RWD 行為。
 - **效益**：移除魔術數字、提升跨頁一致性與維護性；調整寬度僅需變更 `tailwind.config.js`。
+
+### MGT: 共用表單寬度 token 導入（Users 範圍）
+- **範圍與原則**：僅調整「工具列/篩選用途」之 `el-select` 與搜尋 `el-input`；排除表單欄位（維持全寬），避免壓縮與版面破壞。
+- **使用 token**：`min-w-form-control=120`、`md:max-w-form-select=150`、`md:max-w-form-search=280`。
+- **影響檔案**：
+  - `pages/users/index.vue`：搜尋與四個篩選下拉統一 token。
+  - `pages/users/comments/index.vue`：分頁「每頁顯示」下拉統一 token。
+  - `pages/users/applications/index.vue`、`pages/users/favorites/index.vue`：僅驗證，無篩選下拉/搜尋需改動。
+- **結果**：370px 下全寬、md+ 套上限；Lint 綠燈、無版面破壞。
+
+### MGT: 共用表單寬度 token 導入（Company 範圍）
+- **範圍與原則**：同 users；只調整工具列/篩選用途，表單欄位保持全寬。
+- **影響檔案**：
+  - `pages/company/index.vue`：搜尋與四個篩選下拉改用 token。
+  - `pages/company/comments/index.vue`：評分/日期排序/每頁顯示下拉改用 token。
+  - `pages/company/programs/[programId]/applicants/index.vue`：待審核/已審核區的排序/狀態下拉改用 token。
+  - `pages/company/programs/new.vue`：產業/職類/體驗人數/刊登期間下拉改用 token（其餘表單欄位維持全寬）。
+  - `pages/company/settings/index.vue`：產業/規模下拉改用 token（地址縣市/區域暫留全寬）。
+- **結果**：RWD 驗證通過、Lint 綠燈；移除魔術數字，提升一致性與維護性。


### PR DESCRIPTION
### MGT: 共用表單寬度 token 導入（Users 範圍）
- **範圍與原則**：僅調整「工具列/篩選用途」之 `el-select` 與搜尋 `el-input`；排除表單欄位（維持全寬），避免壓縮與版面破壞。
- **使用 token**：`min-w-form-control=120`、`md:max-w-form-select=150`、`md:max-w-form-search=280`。
- **影響檔案**：
  - `pages/users/index.vue`：搜尋與四個篩選下拉統一 token。
  - `pages/users/comments/index.vue`：分頁「每頁顯示」下拉統一 token。
  - `pages/users/applications/index.vue`、`pages/users/favorites/index.vue`：僅驗證，無篩選下拉/搜尋需改動。
- **結果**：370px 下全寬、md+ 套上限；Lint 綠燈、無版面破壞。

### MGT: 共用表單寬度 token 導入（Company 範圍）
- **範圍與原則**：同 users；只調整工具列/篩選用途，表單欄位保持全寬。
- **影響檔案**：
  - `pages/company/index.vue`：搜尋與四個篩選下拉改用 token。
  - `pages/company/comments/index.vue`：評分/日期排序/每頁顯示下拉改用 token。
  - `pages/company/programs/[programId]/applicants/index.vue`：待審核/已審核區的排序/狀態下拉改用 token。
  - `pages/company/programs/new.vue`：產業/職類/體驗人數/刊登期間下拉改用 token（其餘表單欄位維持全寬）。
  - `pages/company/settings/index.vue`：產業/規模下拉改用 token（地址縣市/區域暫留全寬）。
- **結果**：RWD 驗證通過、Lint 綠燈；移除魔術數字，提升一致性與維護性。