### PR TITLE
Feat/admin pp2 UI  dashboard

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -25,6 +25,9 @@ const handleNav = (item: { key: string; label: string }, idx: number) => {
   if (item.key === 'comments') {
     navigateTo(adminRoutes.comments())
   }
+  if (item.key === 'dashboard') {
+    navigateTo(adminRoutes.dashboard())
+  }
 }
 </script>
 

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -104,7 +104,7 @@
       </div>
     </section>
 
-    <!-- 下個任務：體驗者端數據 -->
+    <!-- 體驗者端數據 -->
     <section class="space-y-4">
       <h2 class="text-xl font-semibold text-gray-900 md:text-2xl">體驗者端數據</h2>
 
@@ -170,11 +170,38 @@
       </div>
     </section>
 
+    <!-- 下個任務：熱門體驗計畫 -->
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-xl font-semibold text-gray-900 md:text-2xl">熱門體驗計畫</h2>
+        <button type="button" class="inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" @click="goToAllPopular">
+          查看全部
+          <ArrowRight class="h-4 w-4" />
+        </button>
+      </div>
+
+      <div class="overflow-hidden rounded border border-gray-200 bg-white">
+        <div
+          v-for="p in popularPrograms"
+          :key="p.id"
+          class="grid grid-cols-1 gap-2 border-b border-gray-100 px-4 py-3 last:border-b-0 md:grid-cols-3 md:items-center md:py-4"
+        >
+          <div class="min-w-0">
+            <div class="truncate font-semibold text-gray-900">{{ p.title }}</div>
+            <div class="mt-1 text-sm text-gray-600">瀏覽次數：{{ p.views }} 次</div>
+          </div>
+          <div class="text-sm text-gray-800 md:text-center">收藏次數：{{ p.favorites }} 次</div>
+          <div class="text-sm text-gray-800 md:text-right">已申請人數：{{ p.applicants }} 人</div>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Calendar, User, StarFilled, TrendCharts } from '@element-plus/icons-vue'
+import { Calendar, User, StarFilled, TrendCharts, ArrowRight } from '@element-plus/icons-vue'
+import { navigateTo } from '#app'
+import { adminRoutes } from '~/utils/adminRoutes'
 
 definePageMeta({
   name: 'admin-dashboard',
@@ -187,4 +214,17 @@ const metrics = [
   { key: 'newReviews', label: '新增評價', value: '356', icon: 'star', delta: '15% 增長', note: '相比上個月' },
   { key: 'avgRating', label: '平均評分', value: '4.7', icon: 'chart', delta: '0.2 增長', note: '相比上個月' },
 ]
+
+const popularPrograms = [
+  { id: 1, title: '企業參訪體驗計畫', views: 42, favorites: 42, applicants: 42 },
+  { id: 2, title: '職場導師計畫', views: 42, favorites: 42, applicants: 42 },
+  { id: 3, title: '創業工作坊', views: 42, favorites: 42, applicants: 42 },
+  { id: 4, title: '數位行銷實戰', views: 42, favorites: 42, applicants: 42 },
+  { id: 5, title: '創業工作坊', views: 42, favorites: 42, applicants: 42 },
+  { id: 6, title: '數位行銷實戰', views: 42, favorites: 42, applicants: 42 },
+]
+
+const goToAllPopular = () => {
+  navigateTo(adminRoutes.trends())
+}
 </script>

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -103,6 +103,73 @@
         </el-card>
       </div>
     </section>
+
+    <!-- 下個任務：體驗者端數據 -->
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-gray-900 md:text-2xl">體驗者端數據</h2>
+
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <!-- 申請活動 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">申請活動</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 評價總數 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">評價總數</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 被收藏最愛職業數量（每月） -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">被收藏最愛職業數量（每月）</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 當月被收藏最愛的職業種類 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">當月被收藏最愛的職業種類</div>
+          </template>
+          <div class="flex h-56 w-full flex-col justify-between">
+            <div class="flex flex-1 items-center justify-center">
+              <div class="h-40 w-40 rounded-full bg-brand-gray"></div>
+            </div>
+            <div class="mt-3 flex items-center gap-6 text-sm">
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-green-400"></span>綠色產業類</span>
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-blue-400"></span>資訊類</span>
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-gray-500"></span>行銷與設計類</span>
+            </div>
+          </div>
+        </el-card>
+      </div>
+    </section>
+
   </div>
 </template>
 

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="mx-auto w-full max-w-container-admin space-y-6">
+    <!-- Title & Intro -->
+    <section>
+      <h1 class="text-2xl font-semibold text-gray-900 md:text-3xl">儀表板</h1>
+      <p class="mt-1 text-sm text-gray-600">歡迎回來，管理員！以下是平台的最新統計數據。</p>
+    </section>
+
+    <!-- Stats cards -->
+    <section>
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div
+          v-for="m in metrics"
+          :key="m.key"
+          class="rounded border border-gray-200 bg-white p-5 shadow-sm"
+        >
+          <div class="flex items-center gap-3 text-gray-700">
+            <div class="flex h-10 w-10 items-center justify-center rounded bg-brand-gray text-gray-600">
+              <CalendarIcon v-if="m.icon === 'calendar'" class="h-6 w-6" />
+              <svg v-else-if="m.icon === 'users'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                <path d="M7.5 6a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0zM3 18.25a6.5 6.5 0 0113 0c0 .414-.336.75-.75.75h-11.5a.75.75 0 01-.75-.75zM17.25 7.5a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zM15.75 12.75c1.933 0 3.75.78 5.06 2.04.188.177.29.424.29.682v2.778a.75.75 0 01-.75.75h-3.594" />
+              </svg>
+              <StarIcon v-else-if="m.icon === 'star'" class="h-6 w-6" />
+              <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                <path d="M3 3.75A.75.75 0 013.75 3h.5a.75.75 0 01.75.75v15.5a.75.75 0 01-.75.75h-.5A.75.75 0 013 19.25V3.75zM8.5 9.75A.75.75 0 019.25 9h.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75v-9.5zM14 6.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-.5A.75.75 0 0114 19.25V6.75zM19.5 12.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v6.5a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75v-6.5z" />
+              </svg>
+            </div>
+            <div class="text-sm text-gray-600">{{ m.label }}</div>
+          </div>
+          <div class="mt-3 text-3xl font-semibold text-gray-900">{{ m.value }}</div>
+          <div class="mt-2 flex items-center gap-2 text-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-4 w-4 text-green-600">
+              <path fill-rule="evenodd" d="M12 5.25a.75.75 0 01.75.75v10.19l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 111.06-1.06l3.22 3.22V6a.75.75 0 01.75-.75z" clip-rule="evenodd" />
+            </svg>
+            <span class="text-green-600">{{ m.delta }}</span>
+            <span class="text-gray-500">{{ m.note }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import CalendarIcon from '~/components/CalendarIcon.vue'
+import StarIcon from '~/components/StarIcon.vue'
+
+definePageMeta({
+  name: 'admin-dashboard',
+  layout: 'admin',
+});
+
+const metrics = [
+  { key: 'totalPrograms', label: '總體驗計畫', value: '248', icon: 'calendar', delta: '12% 增長', note: '相比上個月' },
+  { key: 'activeUsers', label: '活躍用戶', value: '1,842', icon: 'users', delta: '8% 增長', note: '相比上個月' },
+  { key: 'newReviews', label: '新增評價', value: '356', icon: 'star', delta: '15% 增長', note: '相比上個月' },
+  { key: 'avgRating', label: '平均評分', value: '4.7', icon: 'chart', delta: '0.2 增長', note: '相比上個月' },
+]
+</script>

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -16,14 +16,10 @@
         >
           <div class="flex items-center gap-3 text-gray-700">
             <div class="flex h-10 w-10 items-center justify-center rounded bg-brand-gray text-gray-600">
-              <CalendarIcon v-if="m.icon === 'calendar'" class="h-6 w-6" />
-              <svg v-else-if="m.icon === 'users'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
-                <path d="M7.5 6a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0zM3 18.25a6.5 6.5 0 0113 0c0 .414-.336.75-.75.75h-11.5a.75.75 0 01-.75-.75zM17.25 7.5a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zM15.75 12.75c1.933 0 3.75.78 5.06 2.04.188.177.29.424.29.682v2.778a.75.75 0 01-.75.75h-3.594" />
-              </svg>
-              <StarIcon v-else-if="m.icon === 'star'" class="h-6 w-6" />
-              <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
-                <path d="M3 3.75A.75.75 0 013.75 3h.5a.75.75 0 01.75.75v15.5a.75.75 0 01-.75.75h-.5A.75.75 0 013 19.25V3.75zM8.5 9.75A.75.75 0 019.25 9h.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75v-9.5zM14 6.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-.5A.75.75 0 0114 19.25V6.75zM19.5 12.75a.75.75 0 01.75-.75h.5a.75.75 0 01.75.75v6.5a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75v-6.5z" />
-              </svg>
+              <Calendar v-if="m.icon === 'calendar'" class="h-6 w-6" />
+              <User v-else-if="m.icon === 'users'" class="h-6 w-6" />
+              <StarFilled v-else-if="m.icon === 'star'" class="h-6 w-6" />
+              <TrendCharts v-else class="h-6 w-6" />
             </div>
             <div class="text-sm text-gray-600">{{ m.label }}</div>
           </div>
@@ -42,8 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import CalendarIcon from '~/components/CalendarIcon.vue'
-import StarIcon from '~/components/StarIcon.vue'
+import { Calendar, User, StarFilled, TrendCharts } from '@element-plus/icons-vue'
 
 definePageMeta({
   name: 'admin-dashboard',

--- a/pages/admin/dashboard/index.vue
+++ b/pages/admin/dashboard/index.vue
@@ -34,6 +34,75 @@
         </div>
       </div>
     </section>
+
+    <!-- Enterprise analytics -->
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-gray-900 md:text-2xl">企業端數據</h2>
+
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <!-- 註冊帳號統計 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">註冊帳號統計</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <!-- y label -->
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <!-- chart placeholder -->
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <!-- x label -->
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 活動發布統計趨勢 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">活動發布統計趨勢</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 活動成團統計趨勢 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">活動成團統計趨勢</div>
+          </template>
+          <div class="relative h-56 w-full overflow-hidden rounded bg-white">
+            <span class="absolute left-0 top-0 translate-y-1.5 text-xs text-gray-500">數量</span>
+            <div class="absolute inset-0 translate-y-2 p-4">
+              <div class="h-full w-full rounded bg-brand-gray"></div>
+            </div>
+            <span class="absolute bottom-1 right-2 text-xs text-gray-500">月份</span>
+          </div>
+        </el-card>
+
+        <!-- 當月發布體驗的職業種類 -->
+        <el-card shadow="never" body-class="p-4">
+          <template #header>
+            <div class="text-base font-semibold text-gray-900">當月發布體驗的職業種類</div>
+          </template>
+          <div class="flex h-56 w-full flex-col justify-between">
+            <div class="flex flex-1 items-center justify-center">
+              <div class="h-40 w-40 rounded-full bg-brand-gray"></div>
+            </div>
+            <div class="mt-3 flex items-center gap-6 text-sm">
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-green-400"></span>綠色產業類</span>
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-blue-400"></span>資訊類</span>
+              <span class="inline-flex items-center gap-2 text-gray-700"><span class="inline-block h-3 w-3 rounded-sm bg-gray-500"></span>行銷與設計類</span>
+            </div>
+          </div>
+        </el-card>
+      </div>
+    </section>
   </div>
 </template>
 

--- a/project-steps.md
+++ b/project-steps.md
@@ -656,4 +656,11 @@
 - **企業端數據區塊**：依設計稿完成 2×2 卡片（註冊帳號統計、活動發布統計趨勢、活動成團統計趨勢、當月發布體驗的職業種類），以 `ElCard` 搭配圖表占位容器、座標標示與圖例占位，先行完成切版。
 - **體驗者端數據區塊**：新增 2×2 卡片（申請活動、評價總數、被收藏最愛職業數量（每月）、當月被收藏最愛的職業種類），結構與企業端一致，預留後續導入圖表庫。
 - **RWD 與規範**：手機 1 欄、`md` 2 欄；裝置寬度下限 370px；沿用專案色票 `brand-gray` 等；不覆蓋 Element Plus 預設樣式，避免衝突。
-- **品質與風險**：未新增依賴、Lint 綠燈；以占位容器隔離圖表實作，後續可最小改動導入 ECharts／Chart.js／ApexCharts；預留 Loading/Empty/Error 三態掛點。gi
+- **品質與風險**：未新增依賴、Lint 綠燈；以占位容器隔離圖表實作，後續可最小改動導入 ECharts／Chart.js／ApexCharts；預留 Loading/Empty/Error 三態掛點。
+
+### PP2: 儀表板 — 熱門體驗計畫區塊與導覽
+- **新增區塊**：在 `pages/admin/dashboard/index.vue` 建立「熱門體驗計畫」清單卡，三欄資訊（標題＋瀏覽數、收藏數、申請人數），行動版單欄、`md` 三欄。
+- **導覽行為**：為「查看全部」按鈕綁定 `navigateTo(adminRoutes.trends())`，對應 `pages/admin/trends/index.vue`（`definePageMeta.name = 'admin-trends'`）。
+- **資料來源**：以 `popularPrograms` 假資料陣列驅動，欄位含 `id/title/views/favorites/applicants`，後續可以 `useFetch` 替換。
+- **圖示與樣式**：使用 EP 圖示 `ArrowRight`，容器採 `rounded border bg-white` 與分隔線；保持 `max-w-container-admin` 版心與既有色票。
+- **品質**：無新增依賴、Lint 綠燈；路由集中於 `utils/adminRoutes.ts`，避免硬編碼字串。

--- a/project-steps.md
+++ b/project-steps.md
@@ -649,3 +649,11 @@
 ### PP7: 提交審核後導回列表
 - **導航行為**：按下「提交審核」後，先預設非同步成功，直接 `navigateTo(adminRoutes.comments())` 導回列表頁。
 - **理由**：先走通 UX 流程；待串接真實 API 後再補請求與錯誤處理。
+
+### PP2: 管理儀表板（Dashboard）UI - 指標與統計卡片
+- **建立頁面與路由**：在 `pages/admin/dashboard/index.vue` 設定 `definePageMeta({ name: 'admin-dashboard', layout: 'admin' })`，以 `layouts/admin.vue` 為共同佈局、版心 `max-w-container-admin`。
+- **頂部指標卡**：實作四張統計卡（總體驗計畫／活躍用戶／新增評價／平均評分），使用 Element Plus Icons（Calendar、User、StarFilled、TrendCharts）取代內嵌 SVG，採 Tailwind 控制尺寸與色彩（`currentColor`）。
+- **企業端數據區塊**：依設計稿完成 2×2 卡片（註冊帳號統計、活動發布統計趨勢、活動成團統計趨勢、當月發布體驗的職業種類），以 `ElCard` 搭配圖表占位容器、座標標示與圖例占位，先行完成切版。
+- **體驗者端數據區塊**：新增 2×2 卡片（申請活動、評價總數、被收藏最愛職業數量（每月）、當月被收藏最愛的職業種類），結構與企業端一致，預留後續導入圖表庫。
+- **RWD 與規範**：手機 1 欄、`md` 2 欄；裝置寬度下限 370px；沿用專案色票 `brand-gray` 等；不覆蓋 Element Plus 預設樣式，避免衝突。
+- **品質與風險**：未新增依賴、Lint 綠燈；以占位容器隔離圖表實作，後續可最小改動導入 ECharts／Chart.js／ApexCharts；預留 Loading/Empty/Error 三態掛點。gi

--- a/utils/adminRoutes.ts
+++ b/utils/adminRoutes.ts
@@ -21,6 +21,7 @@ export const adminRoutes = {
     name: 'admin-comment-review',
     params: { commentId },
   }),
+  dashboard: () => ({ name: 'admin-dashboard' }),
 };
 
 


### PR DESCRIPTION
### PP2: 管理儀表板（Dashboard）UI - 指標與統計卡片
- **建立頁面與路由**：在 `pages/admin/dashboard/index.vue` 設定 `definePageMeta({ name: 'admin-dashboard', layout: 'admin' })`，以 `layouts/admin.vue` 為共同佈局、版心 `max-w-container-admin`。
- **頂部指標卡**：實作四張統計卡（總體驗計畫／活躍用戶／新增評價／平均評分），使用 Element Plus Icons（Calendar、User、StarFilled、TrendCharts）取代內嵌 SVG，採 Tailwind 控制尺寸與色彩（`currentColor`）。
- **企業端數據區塊**：依設計稿完成 2×2 卡片（註冊帳號統計、活動發布統計趨勢、活動成團統計趨勢、當月發布體驗的職業種類），以 `ElCard` 搭配圖表占位容器、座標標示與圖例占位，先行完成切版。
- **體驗者端數據區塊**：新增 2×2 卡片（申請活動、評價總數、被收藏最愛職業數量（每月）、當月被收藏最愛的職業種類），結構與企業端一致，預留後續導入圖表庫。
- **RWD 與規範**：手機 1 欄、`md` 2 欄；裝置寬度下限 370px；沿用專案色票 `brand-gray` 等；不覆蓋 Element Plus 預設樣式，避免衝突。
- **品質與風險**：未新增依賴、Lint 綠燈；以占位容器隔離圖表實作，後續可最小改動導入 ECharts／Chart.js／ApexCharts；預留 Loading/Empty/Error 三態掛點。

### PP2: 儀表板 — 熱門體驗計畫區塊與導覽
- **新增區塊**：在 `pages/admin/dashboard/index.vue` 建立「熱門體驗計畫」清單卡，三欄資訊（標題＋瀏覽數、收藏數、申請人數），行動版單欄、`md` 三欄。
- **導覽行為**：為「查看全部」按鈕綁定 `navigateTo(adminRoutes.trends())`，對應 `pages/admin/trends/index.vue`（`definePageMeta.name = 'admin-trends'`）。
- **資料來源**：以 `popularPrograms` 假資料陣列驅動，欄位含 `id/title/views/favorites/applicants`，後續可以 `useFetch` 替換。
- **圖示與樣式**：使用 EP 圖示 `ArrowRight`，容器採 `rounded border bg-white` 與分隔線；保持 `max-w-container-admin` 版心與既有色票。
- **品質**：無新增依賴、Lint 綠燈；路由集中於 `utils/adminRoutes.ts`，避免硬編碼字串。