### PR TITLE
Feat/layouts  admin login entrance link

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -35,7 +35,7 @@ const handleNav = (item: { key: string; label: string }, idx: number) => {
 <template>
   <div class="min-h-screen w-full bg-white text-gray-900">
     <!-- Top bar -->
-    <header class="flex h-16 w-full items-center justify-between bg-gray-700 px-4 text-white md:px-8">
+    <header class="flex h-16 w-full items-center justify-between bg-gray-700 px-4 text-white md:px-6 xl:px-8">
       <div class="flex items-center gap-3">
         <div class="flex h-8 w-12 items-center justify-center rounded bg-gray-600 text-[10px]">LOGO</div>
         <span class="text-lg font-semibold md:text-xl">TRYβ管理後台系統</span>
@@ -57,13 +57,14 @@ const handleNav = (item: { key: string; label: string }, idx: number) => {
       </div>
     </header>
 
-    <div class="flex">
+    <div class="flex flex-col md:flex-row">
+      <!-- Overlay for mobile sidebar -->
       <!-- Sidebar -->
       <aside
-        class="fixed inset-y-16 left-0 z-30 w-64 translate-x-0 border-r border-gray-200 bg-white pt-6 transition-transform md:static md:inset-auto md:translate-x-0"
-        :class="{ '-translate-x-full': !isSidebarOpen, 'md:translate-x-0': true }"
+        class="w-full overflow-hidden bg-white transition-[max-height] duration-500 ease-in-out md:static md:h-auto md:max-h-full md:w-60 md:border-r md:transition-none xl:w-64"
+        :class="isSidebarOpen ? 'max-h-screen' : 'max-h-0 md:max-h-full'"
       >
-        <nav class="space-y-6 px-6">
+        <nav class="space-y-6 px-6 py-6">
           <button
             v-for="(item, idx) in navItems"
             :key="item.key"
@@ -79,7 +80,7 @@ const handleNav = (item: { key: string; label: string }, idx: number) => {
       </aside>
 
       <!-- Content -->
-      <main class="ml-0 flex min-h-[calc(100vh-4rem)] w-full flex-col p-4 md:p-8">
+      <main class="ml-0 flex min-h-[calc(100vh-4rem)] w-full flex-col p-4 md:p-6 xl:p-8">
         <slot />
       </main>
     </div>

--- a/project-steps.md
+++ b/project-steps.md
@@ -664,3 +664,16 @@
 - **資料來源**：以 `popularPrograms` 假資料陣列驅動，欄位含 `id/title/views/favorites/applicants`，後續可以 `useFetch` 替換。
 - **圖示與樣式**：使用 EP 圖示 `ArrowRight`，容器採 `rounded border bg-white` 與分隔線；保持 `max-w-container-admin` 版心與既有色票。
 - **品質**：無新增依賴、Lint 綠燈；路由集中於 `utils/adminRoutes.ts`，避免硬編碼字串。
+
+### 2025-08-15
+### LAYOUT: 管理後台 RWD 與 UX 優化
+- **基礎 RWD 適配**：為 `layouts/admin.vue` 的 Header、Sidebar 及 Main Content 區域新增 `md` 與 `xl` 斷點，調整各區塊在不同螢幕尺寸下的 `padding` 與 `width`，建立初步的響應式佈局。
+- **行動裝置側邊欄迭代 (側向滑動)**：
+  - 實作漢堡選單 (`isSidebarOpen` 狀態) 控制側邊欄的顯示與隱藏。
+  - 採用 `position: fixed` 搭配 `transform: translateX` 製作側邊欄滑入/滑出動畫。
+  - 新增半透明遮罩 (`Overlay`)，提供點擊關閉的便利性，並透過 Vue `<transition>` 優化淡入淡出效果。
+- **行動裝置側邊欄重構 (垂直展開)**：
+  - 為滿足「內容下推」及「垂直動畫」的 UX 需求，將外層容器在 `md` 以下改為 `flex-col`。
+  - 捨棄 `transform`，改用 `transition-[max-height]` 搭配 `max-h-0` 和 `max-h-screen`，實現流暢的垂直展開/收合動畫，並自然地將主內容區塊向下推移。
+  - 在此新架構下，移除了不再需要的遮罩層，簡化了 DOM 結構與程式碼。
+  - 最終將側邊欄在行動裝置上的寬度設為 `w-full`，以符合最終設計要求。


### PR DESCRIPTION
### 2025-08-15
### LAYOUT: 管理後台 RWD 與 UX 優化
- **基礎 RWD 適配**：為 `layouts/admin.vue` 的 Header、Sidebar 及 Main Content 區域新增 `md` 與 `xl` 斷點，調整各區塊在不同螢幕尺寸下的 `padding` 與 `width`，建立初步的響應式佈局。
- **行動裝置側邊欄迭代 (側向滑動)**：
  - 實作漢堡選單 (`isSidebarOpen` 狀態) 控制側邊欄的顯示與隱藏。
  - 採用 `position: fixed` 搭配 `transform: translateX` 製作側邊欄滑入/滑出動畫。
  - 新增半透明遮罩 (`Overlay`)，提供點擊關閉的便利性，並透過 Vue `<transition>` 優化淡入淡出效果。
- **行動裝置側邊欄重構 (垂直展開)**：
  - 為滿足「內容下推」及「垂直動畫」的 UX 需求，將外層容器在 `md` 以下改為 `flex-col`。
  - 捨棄 `transform`，改用 `transition-[max-height]` 搭配 `max-h-0` 和 `max-h-screen`，實現流暢的垂直展開/收合動畫，並自然地將主內容區塊向下推移。
  - 在此新架構下，移除了不再需要的遮罩層，簡化了 DOM 結構與程式碼。
  - 最終將側邊欄在行動裝置上的寬度設為 `w-full`，以符合最終設計要求。