### PR TITLE
Feat/layouts  admin login entrance link

### DIFF
--- a/layouts/company.vue
+++ b/layouts/company.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { ref } from 'vue';
 import {
   Bell,
   Briefcase,
@@ -13,6 +14,7 @@ import {
 import { companyRoutes as r } from '~/utils/companyRoutes';
 
 const router = useRouter();
+const isSidebarOpen = ref(false);
 
 const programsPath = router.resolve(r.landing()).path;  // 計畫列表
 const newProgramPath = router.resolve(r.newProgram()).path; // 新增體驗
@@ -26,33 +28,43 @@ const settingsPath = router.resolve(r.settings()).path; // 帳戶設定
     <!-- Header -->
     <el-header class="fixed top-0 left-0 right-0 z-20 flex items-center justify-between bg-white border-b px-6">
       <div class="flex items-center gap-2">
+        
         <h1 class="text-xl font-bold">
           TRY ß 職業體驗平台
         </h1>
       </div>
-      <div class="flex items-center gap-6">
-        <el-badge :value="1" class="item" type="primary">
-          <el-button :icon="Bell" circle />
-        </el-badge>
-        <div class="flex items-center gap-2">
-          <el-avatar :size="32" src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png" />
-          <div>
-            <div class="text-sm font-medium">
-              企業管理員
-            </div>
-            <div class="text-xs text-gray-500">
-              陳曉明
+      <div class="flex items-center">
+        <div class=" items-center gap-6 flex">
+          <el-badge :value="1" class="item" type="primary">
+            <el-button :icon="Bell" circle />
+          </el-badge>
+          <div class="flex items-center gap-2">
+            <el-avatar :size="32" src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png" />
+            <div>
+              <div class="text-sm font-medium">
+                企業管理員
+              </div>
+              <div class="text-xs text-gray-500">
+                陳曉明
+              </div>
             </div>
           </div>
         </div>
+        <button class="p-2 md:hidden" @click="isSidebarOpen = !isSidebarOpen" aria-label="切換選單">
+          <el-icon :size="24"><IconMenu /></el-icon>
+        </button>
       </div>
     </el-header>
 
     <!-- Main Container -->
-    <el-container class="pt-[60px]">
+    <div class="flex flex-col pt-[60px] md:flex-row">
       <!-- Sidebar -->
-      <el-aside width="240px" class="fixed top-[60px] left-0 bottom-0 bg-white border-r z-10">
-        <el-menu :default-active="$route.path" router class="h-full !border-r-0">
+      <el-aside
+        width="auto"
+        class="w-full overflow-y-hidden bg-white transition-[max-height] duration-500 ease-in-out md:static md:h-auto md:max-h-full md:!w-[200px] md:border-r md:transition-none"
+        :class="isSidebarOpen ? 'max-h-screen' : 'max-h-0 md:max-h-full'"
+      >
+        <el-menu :default-active="$route.path" router class="!border-r-0">
           <el-menu-item :index="programsPath">
             <el-icon><icon-menu /></el-icon>
             <span>計畫列表</span>
@@ -69,7 +81,7 @@ const settingsPath = router.resolve(r.settings()).path; // 帳戶設定
             <el-icon><Setting /></el-icon>
             <span>帳戶設定</span>
           </el-menu-item>
-          <div class="grow" />
+          <div class="hidden grow md:block" />
           <el-menu-item :index="purchasePath">
             <el-icon><Briefcase /></el-icon>
             <span>方案</span>
@@ -82,10 +94,10 @@ const settingsPath = router.resolve(r.settings()).path; // 帳戶設定
       </el-aside>
 
       <!-- Page Content -->
-      <el-main class="bg-gray-50 ml-[240px] overflow-y-auto">
+      <el-main class="bg-gray-50 overflow-y-auto">
         <slot />
       </el-main>
-    </el-container>
+    </div>
   </el-container>
 </template>
 

--- a/layouts/main.vue
+++ b/layouts/main.vue
@@ -110,9 +110,9 @@ const socialLinks = ref([
                 <a href="#" class="px-4 py-2 text-gray-700 hover:text-blue-600 transition-colors font-medium">
                   探索我們
                 </a>
-                <a href="#" class="px-4 py-2 text-gray-700 hover:text-blue-600 transition-colors font-medium">
+                <NuxtLink :to="{ name: 'plan' }" class="px-4 py-2 text-gray-700 hover:text-blue-600 transition-colors font-medium">
                   方案
-                </a>
+                </NuxtLink>
                 <div class="px-4 py-2 flex items-center gap-2">
                   <font-awesome-icon :icon="['fas', 'user-circle']" class="w-6 h-6" />
                   <NuxtLink to="/roles" class="text-gray-700 hover:text-blue-600 transition-colors font-medium">

--- a/layouts/main.vue
+++ b/layouts/main.vue
@@ -58,7 +58,7 @@ const socialLinks = ref([
 <template>
   <div>
     <!-- Header (Moved from pages/index.vue) -->
-    <header class="nav-shadow sticky bg-white z-40">
+    <header class="nav-shadow fixed top-0 left-0 w-full bg-white z-40">
       <div class="h-main-header w-full max-w-screen-full-hd mx-auto p-12">
         <nav class="flex h-full items-center justify-between gap-8">
           <!-- 商標 Section -->
@@ -129,7 +129,9 @@ const socialLinks = ref([
     </header>
 
     <!-- Page content will be injected here -->
-    <slot />
+    <main class="pt-[158px]">
+      <slot />
+    </main>
 
     <!-- Footer -->
     <footer class="relative text-white bg-cover bg-center overflow-hidden">

--- a/layouts/main.vue
+++ b/layouts/main.vue
@@ -37,8 +37,9 @@ onBeforeUnmount(() => {
 
 // --- Footer State ---
 const quickLinks = ref([
-  { text: '首頁', href: '/' },
-  { text: '企業方案', href: '/plan' },
+  { text: '首頁', href: { name: 'index' } },
+  { text: '企業方案', href: { name: 'plan' } },
+  { text: '後台登入', href: { name: 'admin-login' } },
 ]);
 
 const contactInfo = ref({

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-definePageMeta({ layout: 'blank' as any })
+definePageMeta({ 
+  name: 'admin-login',
+  layout: 'blank' as any })
 
 import { ref } from 'vue'
 import { navigateTo } from '#app'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@ import linkedinLogo from '@/assets/img/home/partners/linkedin-logo.webp';
 import logo104 from '@/assets/img/home/partners/104-logo.webp';
 import cathaybkLogo from '@/assets/img/home/partners/cathaybk-logo.webp';
 import microsoftLogo from '@/assets/img/home/partners/microsoft-logo.webp';
-
+import { userRoutes } from '~/utils/userRoutes';
 
 definePageMeta({
   name: 'index',
@@ -126,7 +126,7 @@ const stats = [
             <h2 class="mt-16 text-xl font-bold sm:text-2xl lg:text-3xl xl:text-4xl">
               開啟職場任意門，體驗你的無限可能。
             </h2>
-            <NuxtLink to="/roles" class="mt-12 inline-block rounded-md bg-btn-yellow px-8 py-3 font-bold text-black transition-transform hover:scale-105 hover:bg-primary-blue-dark hover:text-white">
+            <NuxtLink :to="userRoutes.landing()" class="mt-12 inline-block rounded-md bg-btn-yellow px-8 py-3 font-bold text-black transition-transform hover:scale-105 hover:bg-primary-blue-dark hover:text-white">
               開始體驗
             </NuxtLink>
           </div>

--- a/pages/roles.vue
+++ b/pages/roles.vue
@@ -6,13 +6,13 @@ definePageMeta({
 
 const roles = ref([
   {
-    title: '我是體驗者',
+    title: '體驗者',
     description: '開啟職場任意門，體驗你的無限可能。',
     features: ['實習與專案合作機會', '多元職涯探索', '實際職務體驗計畫'],
     loginUrl: '/users/login'
   },
   {
-    title: '我是企業',
+    title: '企業',
     description: '每一場體驗，都是品牌加分的機會',
     features: [
       '輕鬆創建和管理您的體驗活動',

--- a/project-steps.md
+++ b/project-steps.md
@@ -684,3 +684,10 @@
   - **漢堡選單**: 將 `<el-button>` 改為原生 `<button>`，解決 `md:hidden` 失效問題。
   - **側邊欄寬度**: 透過 `width="auto"` prop 搭配 `md:!w-[200px]` `!important` 修飾符，成功覆蓋 `<el-aside>` 的內聯樣式，使其在手機版為全寬，桌面版為固定寬度。
   - **側邊欄捲動軸**: 經過多次排查（移除 `h-full`、隱藏 `grow` 元素），最終透過 `overflow-y-hidden` 覆蓋 `<el-aside>` 預設的 `overflow: auto`，徹底解決了手機版側邊欄不應出現的捲動軸問題。
+
+### LAYOUT: 主佈局 Header 固定定位與導覽更新
+- **Header 固定定位**: 將 `layouts/main.vue` 的 `<header>` 從 `sticky` 改為 `fixed` 定位，並將 `<slot />` 包裹於 `<main class="pt-[158px]">` 中，以補償 header 高度，避免內容被遮擋。
+- **頁腳連結新增與重構**:
+  - 在頁腳的「快速連結」中新增了前往後台 (`admin-login`) 的連結。
+  - 將頁腳所有連結的 `href` 值從字串路徑重構為物件形式的命名路由，以提升可維護性。
+- **Header 導覽連結**: 將頂部導覽列中的「方案」連結從 `<a>` 標籤改為 `<NuxtLink>`，並指向 `plan` 命名路由，完成了核心導覽功能的串接。

--- a/project-steps.md
+++ b/project-steps.md
@@ -677,3 +677,10 @@
   - 捨棄 `transform`，改用 `transition-[max-height]` 搭配 `max-h-0` 和 `max-h-screen`，實現流暢的垂直展開/收合動畫，並自然地將主內容區塊向下推移。
   - 在此新架構下，移除了不再需要的遮罩層，簡化了 DOM 結構與程式碼。
   - 最終將側邊欄在行動裝置上的寬度設為 `w-full`，以符合最終設計要求。
+
+### LAYOUT: 企業端佈局 RWD 與樣式衝突修復
+- **RWD 行為對齊**: 為 `layouts/company.vue` 引入與 `admin.vue` 一致的 RWD 行為，包含新增漢堡選單，並將手機版側邊欄重構為「垂直展開」模式。
+- **樣式衝突解決 (迭代)**:
+  - **漢堡選單**: 將 `<el-button>` 改為原生 `<button>`，解決 `md:hidden` 失效問題。
+  - **側邊欄寬度**: 透過 `width="auto"` prop 搭配 `md:!w-[200px]` `!important` 修飾符，成功覆蓋 `<el-aside>` 的內聯樣式，使其在手機版為全寬，桌面版為固定寬度。
+  - **側邊欄捲動軸**: 經過多次排查（移除 `h-full`、隱藏 `grow` 元素），最終透過 `overflow-y-hidden` 覆蓋 `<el-aside>` 預設的 `overflow: auto`，徹底解決了手機版側邊欄不應出現的捲動軸問題。

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,19 +40,19 @@ module.exports = {
       },
       // 在這裡定義全域的斷點，這些斷點會被 container 和 sm:, lg: 等工具類共用
       screens: {
-        sm: "640px",
-        md: "768px",
-        lg: "1024px",
-        xl: "1280px",
+        "sm": "640px",
+        "md": "768px",
+        "lg": "1024px",
+        "xl": "1280px",
         "2xl": "1400px", // 在此設定全域 container 的最大寬度
       },
       // 專為頁首設計的版心寬度
       maxWidth: {
         "screen-full-hd": "1920px",
         "container-main": "1200px",
-        "container-company": "1440px",
-        "container-users": "1440px",
-        "container-admin": "1440px",
+        "container-company": "1200px",
+        "container-users": "1200px",
+        "container-admin": "1200px",
         // 表單控制元件在中大螢幕的最大寬度
         'form-select': '150px',
         'form-search': '280px',


### PR DESCRIPTION
### LAYOUT: 企業端佈局 RWD 與樣式衝突修復
- **RWD 行為對齊**: 為 `layouts/company.vue` 引入與 `admin.vue` 一致的 RWD 行為，包含新增漢堡選單，並將手機版側邊欄重構為「垂直展開」模式。
- **樣式衝突解決 (迭代)**:
  - **漢堡選單**: 將 `<el-button>` 改為原生 `<button>`，解決 `md:hidden` 失效問題。
  - **側邊欄寬度**: 透過 `width="auto"` prop 搭配 `md:!w-[200px]` `!important` 修飾符，成功覆蓋 `<el-aside>` 的內聯樣式，使其在手機版為全寬，桌面版為固定寬度。
  - **側邊欄捲動軸**: 經過多次排查（移除 `h-full`、隱藏 `grow` 元素），最終透過 `overflow-y-hidden` 覆蓋 `<el-aside>` 預設的 `overflow: auto`，徹底解決了手機版側邊欄不應出現的捲動軸問題。

### LAYOUT: 主佈局 Header 固定定位與導覽更新
- **Header 固定定位**: 將 `layouts/main.vue` 的 `<header>` 從 `sticky` 改為 `fixed` 定位，並將 `<slot />` 包裹於 `<main class="pt-[158px]">` 中，以補償 header 高度，避免內容被遮擋。
- **頁腳連結新增與重構**:
  - 在頁腳的「快速連結」中新增了前往後台 (`admin-login`) 的連結。
  - 將頁腳所有連結的 `href` 值從字串路徑重構為物件形式的命名路由，以提升可維護性。
- **Header 導覽連結**: 將頂部導覽列中的「方案」連結從 `<a>` 標籤改為 `<NuxtLink>`，並指向 `plan` 命名路由，完成了核心導覽功能的串接。