### PR TITLE
feat(company): 實作體驗者申請審核頁面

### DIFF
--- a/pages/company/programs/[programId]/applicants/[applicantId].vue
+++ b/pages/company/programs/[programId]/applicants/[applicantId].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 import {
   User,
   Briefcase,
@@ -9,6 +9,8 @@ import {
   Document,
   Download,
 } from '@element-plus/icons-vue';
+import dayjs from 'dayjs';
+import type { ApplicantDetail, ProgramPlan } from '~/types/company/applicant';
 
 const route = useRoute();
 
@@ -17,81 +19,22 @@ definePageMeta({
   layout: 'company',
 });
 
-const applicant = {
-  name: '林威廷',
-  id: 'AP-2025-0458',
-  university: '台灣大學資訊工程學系',
-  experience: '3 年工作經驗',
-  age: '大學生 | 22 歲',
-  location: '台北市松山區南京東路一段210號',
-  rating: 4,
-  ratingCount: 12,
-  email: 'waiting.lin@example.com',
-  phone: '0912-345-678',
-};
+const { data: applicantData, pending } = useAsyncData<ApplicantDetail>(
+  `applicant-${route.params.applicantId}`,
+  () => $fetch(`/api/v1/company/programs/${route.params.programId}/applicants/${route.params.applicantId}`),
+);
 
-const application = {
-  programName: '前端工程師一日體驗',
-  programId: 'PRJ-2025-0102',
-  date: '2025年10月15日 - 2025年10月16日 為期 2 天',
-  location: '台北市信義區松仁路100號',
-  motivation:
-    '我對前端開發抱有濃厚的興趣，希望透過這次體驗營了解實際工作環境和流程。自己雖自學了HTML、CSS和JavaScript，但缺乏專案實作經驗。我相信這次體驗營能幫助我補足這塊的不足，提升我的技術實力。我期待能與貴公司的專業團隊交流學習，並貢獻我的想法。',
-};
-
-const skills = ['HTML5', 'CSS3', 'JavaScript', 'React', 'Vue.js', 'Git', 'UI/UX設計'];
-
-const attachments = [
-  {
-    name: '個人履歷.pdf',
-    size: '2.4MB',
-    date: '2025/07/28',
-    icon: Document,
-  },
-  {
-    name: '作品集.jpg',
-    size: '3.2MB',
-    date: '2025/07/28',
-    icon: Document,
-  },
-  {
-    name: '自我介紹.docx',
-    size: '1.2MB',
-    date: '2025/07/28',
-    icon: Document,
-  },
-];
-
-const pastPrograms = [
-  {
-    name: '軟體工程師體驗營',
-    date: '2025年7月21日 - 2025年7月22日',
-    status: '已參加',
-    review: '表現優良，準時有禮貌',
-    rating: 5,
-  },
-  {
-    name: '軟體工程師體驗營',
-    date: '2025年7月21日 - 2025年7月22日',
-    status: '已參加',
-    review: '表現優良，準時有禮貌',
-    rating: 5,
-  },
-  {
-    name: '軟體工程師體驗營',
-    date: '2025年7月21日 - 2025年7月22日',
-    status: '已參加',
-    review: '表現優良，準時有禮貌',
-    rating: 5,
-  },
-  {
-    name: '軟體工程師體驗營',
-    date: '2025年7月21日 - 2025年7月22日',
-    status: '已參加',
-    review: '表現優良，準時有禮貌',
-    rating: 5,
-  },
-];
+const applicant = computed<Partial<ApplicantDetail>>(() => applicantData.value || {});
+const programPlan = computed<Partial<ProgramPlan>>(() => applicant.value?.program_plan || {});
+const skills = computed(() => applicant.value?.Skills || []);
+const attachments = computed(() => (applicant.value?.PortfolioFiles || []).map(file => ({
+  name: file.title,
+  size: file.file_size,
+  date: 'N/A', // API does not provide date
+  icon: Document,
+  path: file.portfolio_path,
+})));
+const pastPrograms = computed(() => applicant.value?.past_programs || []);
 
 const decisionForm = ref({
   status: 'pending',
@@ -103,10 +46,10 @@ const submitReview = async () => {
   await navigateTo({
     name: 'company-program-applicants-list',
     params: {
-      programId: route.params.programId
-    }
-  })
-}
+      programId: route.params.programId,
+    },
+  });
+};
 </script>
 
 <template>
@@ -134,46 +77,42 @@ const submitReview = async () => {
     </div>
 
     <!-- Main Content -->
-    <div class="space-y-6">
+    <div v-if="pending" class="text-center">
+      資料載入中...
+    </div>
+    <div v-else-if="applicantData" class="space-y-6">
       <!-- Applicant Info -->
       <el-card>
         <div class="flex flex-col md:flex-row items-start gap-6">
           <el-avatar
             :size="100"
-            src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png"
+            :src="applicant.headshot"
           />
           <div class="flex-1">
             <h2 class="text-xl font-bold">
               {{ applicant.name }}
             </h2>
             <p class="text-sm text-zinc-500 mb-4">
-              {{ applicant.id }}
+              {{ applicant.participant_serial_num }}
             </p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2 text-sm text-zinc-700">
               <div class="flex items-center gap-2">
                 <el-icon><User /></el-icon>
-                <span>{{ applicant.age }}</span>
+                <span>{{ applicant.identity_name }} | {{ applicant.age }} 歲</span>
               </div>
               <div class="flex items-center gap-2">
                 <el-icon><Briefcase /></el-icon>
-                <span>{{ applicant.university }}</span>
+                <span>{{ applicant.school_name }} {{ applicant.major }}</span>
               </div>
               <div class="flex items-center gap-2">
                 <el-icon><Briefcase /></el-icon>
-                <span>{{ applicant.experience }}</span>
+                <span>{{ applicant.status_name }}</span>
               </div>
               <div class="flex items-center gap-2">
                 <el-icon><MapLocation /></el-icon>
-                <span>{{ applicant.location }}</span>
+                <span>{{ applicant.address }}</span>
               </div>
-            </div>
-            <div class="flex items-center gap-2 mt-4">
-              <el-rate v-model="applicant.rating" disabled />
-              <span class="text-sm text-zinc-500">({{ applicant.ratingCount }} 次評價)</span>
-            </div>
-          </div>
-          <div class="text-sm text-zinc-700 space-y-2">
-            <div class="flex items-center gap-2">
+              <div class="flex items-center gap-2">
               <el-icon><Link /></el-icon>
               <a :href="`mailto:${applicant.email}`" class="text-blue-500 hover:underline">{{
                 applicant.email
@@ -182,6 +121,11 @@ const submitReview = async () => {
             <div class="flex items-center gap-2">
               <el-icon><Phone /></el-icon>
               <span>{{ applicant.phone }}</span>
+            </div>
+            </div>
+            <div class="flex items-center gap-2 mt-4">
+              <el-rate :model-value="applicant.average_score || 0" disabled />
+              <span class="text-sm text-zinc-500">({{ applicant.review_count || 0 }} 次評價)</span>
             </div>
           </div>
         </div>
@@ -195,12 +139,17 @@ const submitReview = async () => {
           </h3>
         </template>
         <el-descriptions border :column="1">
-          <el-descriptions-item label="前端工程師一日體驗">{{ application.programId }}</el-descriptions-item>
+          <el-descriptions-item label="計畫名稱">
+            {{ programPlan.program_name }}
+          </el-descriptions-item>
+          <el-descriptions-item label="計畫編號">
+            {{ programPlan.serial_num }}
+          </el-descriptions-item>
           <el-descriptions-item label="計畫時間">
-            {{ application.date }}
+            {{ dayjs(programPlan.program_start_date).format('YYYY/MM/DD') }} - {{ dayjs(programPlan.program_end_date).format('YYYY/MM/DD') }} (共 {{ programPlan.program_duration_days }} 天)
           </el-descriptions-item>
           <el-descriptions-item label="體驗地點">
-            {{ application.location }}
+            {{ programPlan.address }}
           </el-descriptions-item>
         </el-descriptions>
       </el-card>
@@ -213,7 +162,7 @@ const submitReview = async () => {
           </h3>
         </template>
         <p class="text-zinc-700 leading-relaxed">
-          {{ application.motivation }}
+          {{ applicant.motivation_content }}
         </p>
       </el-card>
 
@@ -235,7 +184,7 @@ const submitReview = async () => {
       <el-card>
         <template #header>
           <h3 class="font-bold text-zinc-900">
-            附件資料
+            附件資料 (作品集)
           </h3>
         </template>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -252,7 +201,7 @@ const submitReview = async () => {
                 {{ file.name }}
               </p>
               <p class="text-xs text-zinc-500">
-                {{ file.size }} | {{ file.date }}
+                {{ file.size }}
               </p>
             </div>
             <el-button :icon="Download" circle plain />
@@ -268,13 +217,21 @@ const submitReview = async () => {
           </h3>
         </template>
         <el-table :data="pastPrograms" style="width: 100%">
-          <el-table-column prop="name" label="體驗計畫名稱" />
-          <el-table-column prop="date" label="日期" />
-          <el-table-column prop="status" label="體驗參與狀態" />
-          <el-table-column prop="review" label="訪談單位" />
+          <el-table-column prop="program_name" label="體驗計畫名稱" />
+          <el-table-column label="日期">
+            <template #default="{ row }">
+              {{ dayjs(row.program_start_date).format('YYYY/MM/DD') }} - {{ dayjs(row.program_end_date).format('YYYY/MM/DD') }}
+            </template>
+          </el-table-column>
+          <el-table-column prop="participation_status" label="體驗參與狀態" />
+          <el-table-column prop="cancel_reason" label="取消原因">
+            <template #default="{ row }">
+              {{ row.cancel_reason || '-' }}
+            </template>
+          </el-table-column>
           <el-table-column label="體驗評價">
             <template #default="{ row }">
-              <el-rate v-model="row.rating" disabled />
+              <el-rate :model-value="row.review_score || 0" disabled />
             </template>
           </el-table-column>
         </el-table>

--- a/project-steps.md
+++ b/project-steps.md
@@ -18,3 +18,11 @@
 - 建立公司計畫列表 Mock API (`/api/v1/company/[companyId]/programs.get.ts`)
 - 重構 `useProgramStore`，改用響應式 `useFetch` 自動獲取計畫列表
 - 修正 `Program` 型別定義，使其與 Mock API 資料結構一致
+
+#### e-company-8 查看體驗者申請審核頁面
+- 建立單一申請者資料 Mock API (`/api/v1/company/programs/[programId]/applicants/[applicantId].get.ts`)
+- 建立申請者資料型別定義檔案 (`types/company/applicant.ts`)
+- 更新申請者審核頁面 (`applicants/[applicantId].vue`)，串接 Mock API 並套用型別
+- 修正申請者審核頁面中聯絡資訊的排版對齊問題
+- 修正申請計畫區塊的欄位顯示邏輯，確保所有資訊正確呈現
+- 修復因型別推斷不完整導致的 TypeScript 錯誤

--- a/server/api/v1/company/programs/[programId]/applicants/[applicantId].get.ts
+++ b/server/api/v1/company/programs/[programId]/applicants/[applicantId].get.ts
@@ -1,0 +1,65 @@
+import { defineEventHandler, getRouterParam } from 'h3';
+
+export default defineEventHandler((event) => {
+  const programId = getRouterParam(event, 'programId');
+  const applicantId = getRouterParam(event, 'applicantId');
+
+  // Based on the provided spec for applicant details
+  return {
+    name: '蕭宇宏',
+    phone: '0900000000',
+    age: 31,
+    gender: '男',
+    identity_id: 3,
+    identity_name: '學生',
+    address: '基隆市仁愛區123',
+    email: 'umit0527@gmail.com',
+    headshot: 'headshottest', // You might want to replace this with a real image URL
+    participant_serial_num: `AP-${applicantId}`, // Using applicantId for uniqueness
+    school_name: '嘉南藥理大學',
+    major: '觀光系',
+    status_id: 1,
+    status_name: '畢業',
+    review_count: 2,
+    average_score: 3.0,
+    program_plan: {
+      program_name: '暑期生物體驗營',
+      serial_num: `PRJ-${programId}`, // Using programId for uniqueness
+      program_start_date: '2025-09-03T00:00:00',
+      program_end_date: '2025-09-10T00:00:00',
+      program_duration_days: 7,
+      address: '台中市中正區仁愛路一段1號',
+    },
+    motivation_content: '我對這個體驗非常有興趣，希望能學習新技能。',
+    Skills: [
+      'c#',
+      'java',
+    ],
+    PortfolioFiles: [
+      {
+        Id: 1,
+        title: '眼鏡電商',
+        portfolio_path: '/uploads/123.jpg',
+        file_size: '10mb',
+      },
+    ],
+    past_programs: [
+      {
+        program_name: '暑期餐飲體驗營',
+        program_start_date: '2025-07-04T00:00:00',
+        program_end_date: '2025-08-11T00:00:00',
+        participation_status: '已參加',
+        cancel_reason: null,
+        review_score: 1.0,
+      },
+      {
+        program_name: '暑期科技體驗營',
+        program_start_date: '2025-07-02T00:00:00',
+        program_end_date: '2025-08-09T00:00:00',
+        participation_status: '已參加',
+        cancel_reason: null,
+        review_score: 5.0,
+      },
+    ],
+  };
+});

--- a/types/company/applicant.ts
+++ b/types/company/applicant.ts
@@ -1,0 +1,48 @@
+export interface ProgramPlan {
+  program_name: string;
+  serial_num: string;
+  program_start_date: string;
+  program_end_date: string;
+  program_duration_days: number;
+  address: string;
+}
+
+export interface PortfolioFile {
+  Id: number;
+  title: string;
+  portfolio_path: string;
+  file_size: string;
+}
+
+export interface PastProgram {
+  program_name: string;
+  program_start_date: string;
+  program_end_date: string;
+  participation_status: string;
+  cancel_reason: string | null;
+  review_score: number;
+}
+
+export interface ApplicantDetail {
+  name: string;
+  phone: string;
+  age: number;
+  gender: string;
+  identity_id: number;
+  identity_name: string;
+  address: string;
+  email: string;
+  headshot: string;
+  participant_serial_num: string;
+  school_name: string;
+  major: string;
+  status_id: number;
+  status_name: string;
+  review_count: number;
+  average_score: number;
+  program_plan: ProgramPlan;
+  motivation_content: string;
+  Skills: string[];
+  PortfolioFiles: PortfolioFile[];
+  past_programs: PastProgram[];
+}


### PR DESCRIPTION
為「e-company-8 查看體驗者申請審核頁面」功能，建立 Mock API 端點，並將其與對應的前端頁面進行串接與資料綁定。

同時，為本次開發的資料結構建立了完整的 TypeScript 型別定義，確保前後端資料的一致性與程式碼的穩健性。

此頁面是企業端審核流程的核心環節，旨在提供一個清晰、完整的介面，讓企業用戶能詳細檢視申請者的個人資料、學經歷、申請動機、作品集，以及過去的參與紀錄。這為企業做出錄取或拒絕的決定提供了充足的資訊基礎。

-   **Mock API**:
    -   新增 `GET /api/v1/company/programs/[programId]/applicants/[applicantId].get.ts` 端點，用以模擬回傳單一申請者的詳細資料。

-   **TypeScript 型別**:
    -   建立 `types/company/applicant.ts` 檔案，定義 `ApplicantDetail` 及 `ProgramPlan` 等相關介面。
    -   將型別應用於 `useAsyncData` 與 `computed` 屬性，實現了端對端的型別安全，並修復了因型別推斷不完整而導致的錯誤。

-   **UI 與錯誤修復**:
    -   修正了個人資訊卡片右上角聯絡資訊的排版，使其在各種螢幕寬度下皆能正確靠右對齊。
    -   調整了「申請計畫」區塊的 `el-descriptions`
	元件結構，確保計畫名稱、編號等所有欄位都能被正確地渲染。OA