### PR TITLE
feat(company): 整合新增體驗 API 並為其建立專屬型別

### DIFF
--- a/project-steps.md
+++ b/project-steps.md
@@ -26,3 +26,9 @@
 - 修正申請者審核頁面中聯絡資訊的排版對齊問題
 - 修正申請計畫區塊的欄位顯示邏輯，確保所有資訊正確呈現
 - 修復因型別推斷不完整導致的 TypeScript 錯誤
+
+### 2025-08-26
+#### e-comp-9 企業新增體驗活動 API
+- 建立企業新增體驗活動 API 的 TypeScript 型別定義檔案 (`types/company/programCreation.ts`)
+- 分離新增體驗活動的型別定義，避免修改共用的 `program.ts`
+- 更新 `useProgramStore`，使其在 `createProgram` 方法中串接並使用新的 `ProgramCreationResponse` 型別

--- a/stores/company/useProgramStore.ts
+++ b/stores/company/useProgramStore.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
 import { useCompanyAuthStore } from '~/stores/company/useAuthStore';
-import type { ProgramsResponse, Program, CreateProgramPayload } from '~/types/company/program';
+import type { ProgramsResponse, CreateProgramPayload } from '~/types/company/program';
+import type { ProgramCreationResponse } from '~/types/company/programCreation';
 
 export const useCompanyProgramStore = defineStore('company-program', () => {
   const authStore = useCompanyAuthStore();
@@ -43,7 +44,7 @@ export const useCompanyProgramStore = defineStore('company-program', () => {
       return { success: false, error: new Error('User not authenticated') };
     }
 
-    const { data: responseData, error: fetchError } = await useApiFetch(`/api/v1/company/${authStore.companyId}/programs`, {
+    const { data: responseData, error: fetchError } = await useApiFetch<ProgramCreationResponse>(`/api/v1/company/${authStore.companyId}/programs`, {
       method: 'POST',
       body: payload,
     });

--- a/types/company/programCreation.ts
+++ b/types/company/programCreation.ts
@@ -1,0 +1,46 @@
+import type { Industry, JobTitle } from './program';
+
+export interface ProgramCreationStep {
+  Name: string;
+  Description: string;
+}
+
+export interface ProgramCreationResponse {
+  id: number;
+  company_name: string;
+  company_logo: string;
+  company_cover: string;
+  serial_num: string;
+  name: string;
+  intro: string;
+  industry_id: number;
+  job_title_id: number;
+  address: string;
+  address_map: string;
+  contact_name: string;
+  contact_phone: string;
+  contact_email: string;
+  min_people: number;
+  max_people: number;
+  publish_start_date: string;
+  publish_duration_days: number;
+  publish_end_date: string;
+  program_start_date: string;
+  program_end_date: string;
+  program_duration_days: number;
+  status_id: number;
+  status_title: string;
+  views_count: number;
+  favorites_count: number;
+  applied_count: number;
+  score: number;
+  days_left: number;
+  total_views: number;
+  weekly_views: number;
+  daily_views: number;
+  Industry: Industry;
+  JobTitle: JobTitle;
+  Status: null;
+  Images: string[];
+  Steps: ProgramCreationStep[];
+}


### PR DESCRIPTION
本次提交主要完成企業端「新增體驗活動」功能，串接 POST /programs API。

核心決策：
- 建立獨立的 TypeScript 型別檔案 `types/company/programCreation.ts`， 用以定義新增活動 API 的回應 (`ProgramCreationResponse`)。

理由：
- 為了避免與既有的 `program.ts` (`GET /programs/{id}` 所用) 產生耦合。 此舉將「建立資源」與「查詢資源」的回應型別明確分離， 提高了程式碼的清晰度與長期可維護性，預防未來因 API 結構差異而導致的衝突。

實作細節：
- 在 `useProgramStore` 中，`createProgram` 方法現在會使用 `ProgramCreationResponse` 型別來確保 API 回應的型別安全。
- 維持 `program.ts` 的既有結構，不影響計畫列表與詳情頁面的功能。