### PR TITLE
Fix/ep8 data render

### DIFF
--- a/pages/company/programs/[programId]/applicants/index.vue
+++ b/pages/company/programs/[programId]/applicants/index.vue
@@ -71,16 +71,8 @@ const approvedStatus = ref('all')
                 <p class="font-bold">
                   {{ row.applicant_name }}
                 </p>
-                <p class="text-sm text-zinc-500">
-                  {{ row.school }}
-                </p>
               </div>
             </div>
-          </template>
-        </el-table-column>
-        <el-table-column label="科系" min-width="150">
-          <template #default="{ row }">
-            <p>{{ row.major }}</p>
           </template>
         </el-table-column>
         <el-table-column prop="submit_date" label="申請日期" min-width="150" />
@@ -148,16 +140,8 @@ const approvedStatus = ref('all')
                 <p class="font-bold">
                   {{ row.applicant_name }}
                 </p>
-                <p class="text-sm text-zinc-500">
-                  {{ row.school }}
-                </p>
               </div>
             </div>
-          </template>
-        </el-table-column>
-        <el-table-column label="科系" min-width="150">
-          <template #default="{ row }">
-            <p>{{ row.major }}</p>
           </template>
         </el-table-column>
         <el-table-column prop="submit_date" label="申請日期" min-width="150" />

--- a/project-steps.md
+++ b/project-steps.md
@@ -4,4 +4,5 @@
 #### 企業端-申請者列表 (e-comp-7)
 - 修正申請者列表頁面 (`applicants/index.vue`) 的表格欄位綁定，使其與 `e-comp-7` API 回應的欄位名稱 (`applicant_name`, `submit_date`, `review_status` 等) 一致，解決資料無法渲染的問題。
 - 臨時修復點擊「查看」按鈕時因 API 回應缺少 `applicant_id` 而導致的 500 錯誤，暫時改用 `identity` 作為跳轉參數。
+- 優化申請者列表頁面的使用者體驗 (UX)，移除 API 未提供的「科系」與「學校」欄位以避免顯示空白。
 


### PR DESCRIPTION
### 2025-08-27
#### 企業端-申請者列表 (e-comp-7)
- 修正申請者列表頁面 (`applicants/index.vue`) 的表格欄位綁定，使其與 `e-comp-7` API 回應的欄位名稱 (`applicant_name`, `submit_date`, `review_status` 等) 一致，解決資料無法渲染的問題。
- 臨時修復點擊「查看」按鈕時因 API 回應缺少 `applicant_id` 而導致的 500 錯誤，暫時改用 `identity` 作為跳轉參數。
- 優化申請者列表頁面的使用者體驗 (UX)，移除 API 未提供的「科系」與「學校」欄位以避免顯示空白。