### PR TITLE
Feat/api  e comp 17 applicantion review

### DIFF
--- a/composables/api/company/useSubmitReview.ts
+++ b/composables/api/company/useSubmitReview.ts
@@ -1,0 +1,52 @@
+import type { FetchError } from 'ofetch';
+import { useApiFetch } from '~/composables/api/shared/useApiFetch';
+
+interface SubmitReviewPayload {
+  status_id: 1 | 2; // 1 for rejected, 2 for approved
+  comment: string;
+}
+
+export interface SubmitReviewResponse {
+  message: string;
+  status: number;
+  status_title: 'Approved' | 'Rejected' | string;
+  comment: string;
+}
+
+export const useSubmitReview = () => {
+  const loading = ref(false);
+  const error = ref<FetchError | null>(null);
+  const data = ref<SubmitReviewResponse | null>(null);
+
+  const submit = async (
+    programId: string | number,
+    participantId: string | number,
+    payload: SubmitReviewPayload,
+  ) => {
+    loading.value = true;
+    error.value = null;
+    data.value = null;
+
+    const url = `/api/v1/programs/${programId}/applications/${participantId}/review`;
+
+    const { data: result, error: fetchError } = await useApiFetch<SubmitReviewResponse>(url, {
+      method: 'PUT',
+      body: payload,
+    });
+
+    if (fetchError.value) {
+      error.value = fetchError.value;
+    } else {
+      data.value = result.value;
+    }
+
+    loading.value = false;
+  };
+
+  return {
+    submit,
+    loading,
+    error,
+    data,
+  };
+};

--- a/pages/company/programs/[programId]/applicants/[applicantId].vue
+++ b/pages/company/programs/[programId]/applicants/[applicantId].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useApplicant } from '~/composables/api/company/useApplicant';
 import {
   User,
   Briefcase,
@@ -19,7 +20,10 @@ definePageMeta({
   layout: 'company',
 });
 
-const { data: applicantData, pending } = useApplicant(route.params.programId, route.params.applicantId);
+const { data: applicantData, pending } = useApplicant(
+  String(route.params.programId),
+  String(route.params.applicantId),
+);
 
 const applicant = computed<Partial<ApplicantDetail>>(() => applicantData.value || {});
 const programPlan = computed<Partial<ProgramPlan>>(() => applicant.value?.program_plan || {});

--- a/pages/company/programs/[programId]/applicants/[applicantId].vue
+++ b/pages/company/programs/[programId]/applicants/[applicantId].vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, reactive } from 'vue';
 import { useApplicant } from '~/composables/api/company/useApplicant';
+import { useSubmitReview } from '~/composables/api/company/useSubmitReview';
+import { ElMessageBox, ElMessage } from 'element-plus';
+import type { FormInstance, FormRules } from 'element-plus';
 import {
   User,
   Briefcase,
@@ -14,6 +17,14 @@ import dayjs from 'dayjs';
 import type { ApplicantDetail, ProgramPlan } from '~/types/company/applicant';
 
 const route = useRoute();
+const {
+  submit: submitReviewApi,
+  loading: isSubmitting,
+  error: submitError,
+  data: submitResult,
+} = useSubmitReview();
+
+const formRef = ref<FormInstance>();
 
 definePageMeta({
   name: 'company-program-applicant-detail',
@@ -43,12 +54,44 @@ const decisionForm = ref({
   notifyMethod: 'email',
 });
 
-const submitReview = async () => {
-  await navigateTo({
-    name: 'company-program-applicants-list',
-    params: {
-      programId: route.params.programId,
-    },
+const rules = reactive<FormRules>({
+  feedback: [
+    { required: true, message: '請填寫審核意見。', trigger: 'blur' },
+  ],
+});
+
+const submitReview = async (formEl: FormInstance | undefined) => {
+  if (!formEl) return;
+  await formEl.validate(async (valid) => {
+    if (valid) {
+      const programId = String(route.params.programId);
+      const applicantId = String(route.params.applicantId);
+
+      await submitReviewApi(programId, applicantId, {
+        status_id: decisionForm.value.status === 'pending' ? 2 : 1,
+        comment: decisionForm.value.feedback,
+      });
+
+      if (submitError.value) {
+        await ElMessageBox.alert(
+          `提交失敗：${submitError.value.data?.message || submitError.value.message}`,
+          '錯誤',
+          { type: 'error' },
+        );
+      } else if (submitResult.value) {
+        await ElMessageBox.alert(submitResult.value.comment, '審核完成', {
+          type: 'success',
+          callback: async () => {
+            await navigateTo({
+              name: 'company-program-applicants-list',
+              params: {
+                programId,
+              },
+            });
+          },
+        });
+      }
+    }
   });
 };
 </script>
@@ -245,8 +288,13 @@ const submitReview = async () => {
             審核決定
           </h3>
         </template>
-        <el-form :model="decisionForm" label-position="top">
-          <el-form-item label="審核結果">
+        <el-form
+          ref="formRef"
+          :model="decisionForm"
+          :rules="rules"
+          label-position="top"
+        >
+          <el-form-item label="審核結果" prop="status">
             <el-radio-group v-model="decisionForm.status">
               <el-radio :value="'pending'">
                 核准申請
@@ -256,7 +304,7 @@ const submitReview = async () => {
               </el-radio>
             </el-radio-group>
           </el-form-item>
-          <el-form-item label="審核意見">
+          <el-form-item label="審核意見" prop="feedback">
             <el-input
               v-model="decisionForm.feedback"
               type="textarea"
@@ -272,7 +320,11 @@ const submitReview = async () => {
           <el-form-item class="mt-6">
             <div class="flex-1 flex justify-end gap-4">
               <el-button>取消</el-button>
-              <el-button type="primary" @click="submitReview">
+              <el-button
+                type="primary"
+                :loading="isSubmitting"
+                @click="submitReview(formRef)"
+              >
                 提交審核結果
               </el-button>
             </div>

--- a/pages/company/programs/[programId]/applicants/index.vue
+++ b/pages/company/programs/[programId]/applicants/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useApplicants } from '~/composables/api/company/useApplicants';
 
 const route = useRoute()
@@ -10,10 +10,14 @@ definePageMeta({
   layout: 'company',
 });
 
-const { data: applicantsData, pending } = useApplicants(
+const { data: applicantsData, pending, refresh: refreshApplicants } = useApplicants(
   computed(() => authStore.companyId),
   computed(() => Array.isArray(route.params.programId) ? route.params.programId[0] : route.params.programId),
 );
+
+onMounted(() => {
+  refreshApplicants();
+});
 
 const pendingApplicants = computed(() => applicantsData.value?.pending_applications || []);
 const reviewedApplicants = computed(() => applicantsData.value?.reviewed_applications || []);

--- a/project-steps.md
+++ b/project-steps.md
@@ -12,3 +12,10 @@
 - 重構方案相關的 TypeScript 型別定義，將其拆分為 `plan/current.ts` 與 `plan/list.ts`，並置於 `types/company/plan` 子目錄下，以提高程式碼的清晰度與可維護性。
 - 優化方案描述的 UX，為 `description` 欄位為空值的方案提供符合其量級的備用文案，提升頁面資訊完整度與價值感。
 
+#### 企業端-體驗者審核 (e-comp-17)
+- 建立 `useSubmitReview.ts` Composable 封裝審核提交 (`PUT`) 的 API 邏輯，並處理 loading 與 error 狀態。
+- 於申請者詳情頁 (`[applicantId].vue`) 串接審核功能，提交後以 `ElMessageBox` 彈窗提供即時成功或失敗的反饋，並在成功後自動導航回列表頁。
+- 修正 `useSubmitReview` Composable，改用共用的 `useApiFetch` 以確保請求能自動夾帶 JWT token，解決 API 回應「請登入」的認證問題。
+- 導入 Element Plus 的表單驗證機制，為「審核意見」欄位加入必填規則，取代原有的手動 `if` 判斷，以解決後端回應 `400 Bad Request` (缺少 `comment` 欄位) 的問題。
+- 於申請者列表頁 (`applicants/index.vue`) 的 `onMounted` 生命週期中呼叫 `refresh` 方法，確保從審核頁返回時能強制刷新列表，即時反映最新的審核狀態。
+


### PR DESCRIPTION
#### 企業端-體驗者審核 (e-comp-17)
- 建立 `useSubmitReview.ts` Composable 封裝審核提交 (`PUT`) 的 API 邏輯，並處理 loading 與 error 狀態。
- 於申請者詳情頁 (`[applicantId].vue`) 串接審核功能，提交後以 `ElMessageBox` 彈窗提供即時成功或失敗的反饋，並在成功後自動導航回列表頁。
- 修正 `useSubmitReview` Composable，改用共用的 `useApiFetch` 以確保請求能自動夾帶 JWT token，解決 API 回應「請登入」的認證問題。
- 導入 Element Plus 的表單驗證機制，為「審核意見」欄位加入必填規則，取代原有的手動 `if` 判斷，以解決後端回應 `400 Bad Request` (缺少 `comment` 欄位) 的問題。
- 於申請者列表頁 (`applicants/index.vue`) 的 `onMounted` 生命週期中呼叫 `refresh` 方法，確保從審核頁返回時能強制刷新列表，即時反映最新的審核狀態。