### PR TITLE
feat(auth): 實作體驗者註冊 API 串接

### DIFF
--- a/composables/api/users/useUserRegister.ts
+++ b/composables/api/users/useUserRegister.ts
@@ -1,0 +1,24 @@
+import { useApiFetch } from '~/composables/api/shared/useApiFetch';
+import type { UserRegisterData } from '~/types/users/user';
+
+interface RegisterResponse {
+  status: number;
+  message: string;
+  id: number;
+  Role: string;
+  Account: string;
+  Email: string;
+  CreatedAt: string;
+  UpdatedAt: string;
+}
+
+export const useUserRegister = () => {
+  async function register(registerData: UserRegisterData) {
+    return await useApiFetch<RegisterResponse>('/v1/users', {
+      method: 'POST',
+      body: registerData,
+    });
+  }
+
+  return { register };
+};

--- a/project-steps.md
+++ b/project-steps.md
@@ -29,3 +29,10 @@
 #### 通用佈局 (Layouts)
 - 修改 `main.vue` 佈局，將「探索我們」按鈕連結至體驗者首頁 (`user-landing`)，提供訪客快速瀏覽主要內容的入口。
 
+#### 體驗者端-使用者註冊 (u-users-10)
+- 建立 `useUserRegister.ts` Composable 以封裝註冊 API (`POST /api/v1/users`) 的請求邏輯，遵循專案既有的程式碼風格。
+- 更新 `useAuthStore` 中的 `register` 動作，使其使用新建的 Composable 進行 API 呼叫，並加入完整的錯誤處理機制。
+- 擴充 `User` TypeScript 型別，加入 `createdAt` 與 `updatedAt` 欄位，使其與後端 API 回應的資料結構保持一致。
+- 驗證 `register.vue` 頁面的前端邏輯，確保其在註冊成功後能正確顯示成功訊息並將使用者導向登入頁面。
+- 修復 `useAuthStore` 中的 TypeScript 型別推斷錯誤，確保程式碼的健壯性。
+

--- a/stores/user/useAuthStore.ts
+++ b/stores/user/useAuthStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import type { User, UserLoginData, UserRegisterData } from '~/types/users/user';
 import { useUserLogin } from '~/composables/api/users/useUserLogin';
+import { useUserRegister } from '~/composables/api/users/useUserRegister';
 
 export const useUserAuthStore = defineStore('userAuth', () => {
   const tokenCookie = useCookie<string | null>('userAuthToken');
@@ -29,11 +30,12 @@ export const useUserAuthStore = defineStore('userAuth', () => {
   }
 
   async function register(registerData: UserRegisterData) {
-    const { $api } = useNuxtApp();
-    await ($api as typeof $fetch)('/user/register', {
-      method: 'POST',
-      body: registerData,
-    });
+    const userRegister = useUserRegister();
+    const { error } = await userRegister.register(registerData);
+
+    if (error.value) {
+      throw error.value;
+    }
   }
   
   async function logout() {

--- a/types/users/user.ts
+++ b/types/users/user.ts
@@ -8,6 +8,8 @@ export interface User {
   email: string;
   role: 'Participant' | string; // Assuming 'Participant' is a possible role
   avatar?: string; // Optional avatar
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 // Based on the request body for user registration API


### PR DESCRIPTION
將前端註冊頁面與後端 `/api/v1/users` 端點進行整合，提供使用者建立帳號的功能。

決策：
- 遵循現有的程式碼架構，建立獨立的 `useUserRegister.ts` Composable 來封裝 API 請求。
- 在 Pinia store (`useAuthStore`) 中統一管理註冊的動作流程與 狀態。

理由：
- 透過將 API 邏輯封裝在 Composable 中，可以提高程式碼的 可複用性與可維護性，同時讓 store 更專注於狀態管理。
- 確保註冊功能與現有的登入功能 (`useUserLogin`) 在架構上 保持一致性。

其他補充：
- 擴充了 `User` 型別定義，使其與後端 API 回應的資料模型 完全同步。
- 驗證了前端頁面具有完整的成功（導向登入頁）與失敗（顯示 錯誤訊息）處理流程。