### PR TITLE
Feat/api  u users 5  get single event info

### DIFF
--- a/.cursor/rules/nuxt3-dev.mdc
+++ b/.cursor/rules/nuxt3-dev.mdc
@@ -129,3 +129,5 @@ description: AI 協作與開發流程指南，定義了 AI 在實作前、中、
 
 
   請使用繁體中文註解補充說明
+
+  KISS 原則：Keep It Simple, Stupid

--- a/components/shared/ErrorMessage.vue
+++ b/components/shared/ErrorMessage.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+    <!-- 錯誤圖示 -->
+    <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-100 mb-4">
+      <font-awesome-icon 
+        :icon="['fas', 'exclamation-triangle']" 
+        class="h-6 w-6 text-red-600" 
+      />
+    </div>
+    
+    <!-- 錯誤標題 -->
+    <h3 class="text-lg font-medium text-red-800 mb-2">
+      {{ title || '發生錯誤' }}
+    </h3>
+    
+    <!-- 錯誤訊息 -->
+    <p class="text-sm text-red-700 mb-4">
+      {{ message || '很抱歉，載入資料時發生問題。' }}
+    </p>
+    
+    <!-- 下一步行動建議 -->
+    <div class="space-y-2">
+      <p class="text-xs text-red-600 mb-3">建議您嘗試以下步驟：</p>
+      
+      <div class="flex flex-col sm:flex-row gap-2 justify-center">
+        <!-- 重新整理按鈕 -->
+        <button
+          v-if="showRefresh"
+          @click="handleRefresh"
+          class="inline-flex items-center px-3 py-2 border border-red-300 rounded-md text-sm font-medium text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+        >
+          <font-awesome-icon :icon="['fas', 'sync-alt']" class="mr-2" />
+          重新整理
+        </button>
+        
+        <!-- 返回按鈕 -->
+        <button
+          v-if="showBack"
+          @click="handleBack"
+          class="inline-flex items-center px-3 py-2 border border-red-300 rounded-md text-sm font-medium text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+        >
+          <font-awesome-icon :icon="['fas', 'arrow-left']" class="mr-2" />
+          返回列表
+        </button>
+        
+        <!-- 聯絡客服按鈕 -->
+        <button
+          v-if="showContact"
+          @click="handleContact"
+          class="inline-flex items-center px-3 py-2 border border-red-300 rounded-md text-sm font-medium text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+        >
+          <font-awesome-icon :icon="['fas', 'envelope']" class="mr-2" />
+          聯絡客服
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title?: string;           // 錯誤標題
+  message?: string;         // 錯誤訊息
+  showRefresh?: boolean;    // 是否顯示重新整理按鈕
+  showBack?: boolean;       // 是否顯示返回按鈕
+  showContact?: boolean;    // 是否顯示聯絡客服按鈕
+}
+
+interface Emits {
+  (e: 'refresh'): void;    // 重新整理事件
+  (e: 'back'): void;       // 返回事件
+  (e: 'contact'): void;    // 聯絡客服事件
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: '發生錯誤',
+  message: '很抱歉，載入資料時發生問題。',
+  showRefresh: true,
+  showBack: true,
+  showContact: true,
+});
+
+const emit = defineEmits<Emits>();
+
+const handleRefresh = () => {
+  emit('refresh');
+};
+
+const handleBack = () => {
+  emit('back');
+};
+
+const handleContact = () => {
+  emit('contact');
+};
+</script>

--- a/components/shared/SkeletonLoader.vue
+++ b/components/shared/SkeletonLoader.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="animate-pulse">
+    <!-- 標題骨架 -->
+    <div v-if="showTitle" class="mb-4">
+      <div class="h-8 bg-gray-200 rounded-lg w-3/4 mb-2"></div>
+      <div class="h-4 bg-gray-200 rounded w-1/2"></div>
+    </div>
+    
+    <!-- 內容骨架 -->
+    <div class="space-y-4">
+      <!-- 圖片骨架 -->
+      <div v-if="showImage" class="h-48 bg-gray-200 rounded-lg"></div>
+      
+      <!-- 文字行骨架 -->
+      <div v-for="i in lines" :key="i" class="space-y-2">
+        <div 
+          class="h-4 bg-gray-200 rounded"
+          :class="getLineWidth(i)"
+        ></div>
+      </div>
+      
+      <!-- 按鈕骨架 -->
+      <div v-if="showButton" class="pt-2">
+        <div class="h-10 bg-gray-200 rounded-lg w-full"></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  showTitle?: boolean;    // 是否顯示標題骨架
+  showImage?: boolean;    // 是否顯示圖片骨架
+  showButton?: boolean;   // 是否顯示按鈕骨架
+  lines?: number;         // 文字行數
+}
+
+withDefaults(defineProps<Props>(), {
+  showTitle: true,
+  showImage: true,
+  showButton: false,
+  lines: 3,
+});
+
+// 根據行數決定寬度變化，讓骨架看起來更自然
+const getLineWidth = (lineIndex: number) => {
+  const widths = ['w-full', 'w-5/6', 'w-4/5', 'w-3/4', 'w-2/3'];
+  return widths[lineIndex % widths.length] || 'w-full';
+};
+</script>

--- a/composables/api/users/useUserProgramDetail.ts
+++ b/composables/api/users/useUserProgramDetail.ts
@@ -1,0 +1,36 @@
+import type { ProgramDetail } from '~/types/users/programDetail';
+import { useUserApiFetch } from './useUserApiFetch';
+
+/**
+ * 取得單一計畫詳情的 API 邏輯
+ */
+export const useUserProgramDetail = () => {
+  /**
+   * 取得計畫詳情
+   * @param programId 計畫 ID
+   * @returns Promise<ProgramDetail>
+   */
+  const fetchProgramDetail = async (programId: string | number): Promise<ProgramDetail> => {
+    try {
+      // 使用 vite proxy 配置的 API 路徑
+      const url = `/api-proxy/v1/programs/${programId}`;
+      
+      console.log('Fetching program detail:', { programId, url });
+      
+      const response = await useUserApiFetch<ProgramDetail>(url, {
+        method: 'GET',
+      });
+      
+      console.log('Program detail response:', response);
+      
+      return response;
+    } catch (error) {
+      console.error('Error fetching program detail:', error);
+      throw error;
+    }
+  };
+  
+  return {
+    fetchProgramDetail,
+  };
+};

--- a/pages/users/programs/[programId].vue
+++ b/pages/users/programs/[programId].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { userRoutes } from '~/utils/userRoutes';
+import { useUserProgramDetailStore } from '~/stores/user/useUserProgramDetailStore';
 
 definePageMeta({
   name: 'user-program-detail',
@@ -10,7 +11,10 @@ definePageMeta({
 
 const router = useRouter();
 const isFavorited = ref(false);
-const showApply = ref(false); // 新增
+const showApply = ref(false);
+
+// 使用 store 管理計畫詳情
+const programDetailStore = useUserProgramDetailStore();
 
 const toggleFavorite = () => {
   isFavorited.value = !isFavorited.value;
@@ -20,25 +24,63 @@ const goBack = () => {
   router.push({ name: 'user-landing' });
 };
 
-// 假資料：企業資訊（之後可換 API）
-const companyId = ref<number | string>(1);
-const companyName = ref('某某某科技資訊公司');
+// 取得路由參數中的計畫 ID
+const route = useRoute();
+const programId = computed(() => route.params.programId as string);
 
-// 體驗流程與地點（假資料）
-const flowSteps = ref([
-  { label: '階段一', text: '企業介紹與數位行銷產業概況 (1小時)、數位行銷工具與平台介紹 (2小時)' },
-  { label: '階段二', text: '實際案例分析與討論 (1小時)、分組實作：社群媒體行銷策劃 (2小時)' },
-  { label: '階段三', text: '成果發表與專業人員回饋 (3小時)' },
-]);
-const venue = ref('高雄市三民區');
+// 計算屬性：從 store 取得計畫詳情
+const programDetail = computed(() => programDetailStore.programDetail);
+const isLoading = computed(() => programDetailStore.loading);
+const hasError = computed(() => programDetailStore.hasError);
+const errorMessage = computed(() => programDetailStore.error);
 
-// 體驗照片（假資料：之後可換實際圖片 URL）
-const galleryPhotos = ref([
-  { id: 1, src: '', alt: '體驗照片 1' },
-  { id: 2, src: '', alt: '體驗照片 2' },
-  { id: 3, src: '', alt: '體驗照片 3' },
-  { id: 4, src: '', alt: '體驗照片 4' },
-]);
+// 頁面載入時取得計畫詳情
+onMounted(async () => {
+  if (programId.value) {
+    try {
+      await programDetailStore.fetchDetail(programId.value);
+    } catch (error) {
+      console.error('Failed to fetch program detail:', error);
+    }
+  }
+});
+
+// 錯誤處理函數
+const handleRefresh = async () => {
+  if (programId.value) {
+    await programDetailStore.refreshDetail();
+  }
+};
+
+const handleBack = () => {
+  router.push({ name: 'user-landing' });
+};
+
+const handleContact = () => {
+  // 這裡可以實作聯絡客服的邏輯
+  console.log('Contact customer service');
+};
+
+// 日期格式化函數
+const formatDate = (dateString: string) => {
+  if (!dateString || dateString === '0001-01-01T00:00:00') {
+    return '日期未定';
+  }
+  
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) {
+      return '日期格式錯誤';
+    }
+    
+    return `${date.getFullYear()}年${String(date.getMonth() + 1).padStart(2, '0')}月${String(date.getDate()).padStart(2, '0')}日`;
+  } catch (error) {
+    console.error('Error formatting date:', error);
+    return '日期格式錯誤';
+  }
+};
+
+// 移除假資料，使用 store 中的真實資料
 
 const onApplySubmitted = async () => {
   showApply.value = false;
@@ -53,7 +95,14 @@ const onApplySubmitted = async () => {
       <div class="mb-8 flex items-center justify-between">
         <h1 class="text-2xl font-bold text-primary-blue-dark">體驗詳情</h1>
         <div class="flex items-center gap-4">
-          <el-button type="primary" size="large" @click="showApply = true">我要申請</el-button>
+          <el-button 
+            v-if="programDetail" 
+            type="primary" 
+            size="large" 
+            @click="showApply = true"
+          >
+            我要申請
+          </el-button>
           <el-button size="large" @click="goBack">返回列表</el-button>
           <el-button size="large" @click="toggleFavorite">
             <div class="flex items-center gap-2">
@@ -64,11 +113,53 @@ const onApplySubmitted = async () => {
         </div>
       </div>
 
+      <!-- 載入狀態 -->
+      <div v-if="isLoading" class="mb-8">
+        <SharedSkeletonLoader 
+          :show-title="true" 
+          :show-image="true" 
+          :lines="5" 
+        />
+      </div>
+
+      <!-- 錯誤狀態 -->
+      <div v-else-if="hasError" class="mb-8">
+        <SharedErrorMessage
+          :title="'載入計畫詳情失敗'"
+          :message="errorMessage || '載入計畫詳情時發生錯誤'"
+          @refresh="handleRefresh"
+          @back="handleBack"
+          @contact="handleContact"
+        />
+      </div>
+
+      <!-- 計畫詳情內容 -->
+      <div v-else-if="programDetail" class="space-y-8">
+
       <!-- 企業封面區塊 -->
       <section aria-label="企業封面" class="mb-8">
         <div class="relative h-44 w-full rounded-lg bg-gray-300">
-          <!-- 圓形 LOGO 佔位 -->
+          <!-- 企業封面圖片 -->
+          <img 
+            v-if="programDetail.company_cover" 
+            :src="programDetail.company_cover" 
+            class="w-full h-full object-cover rounded-lg"
+            alt="企業封面"
+          />
+          
+          <!-- 圓形 LOGO -->
           <div
+            v-if="programDetail.company_logo"
+            class="absolute left-6 top-6 flex h-16 w-16 items-center justify-center rounded-full border-2 border-gray-600 bg-white overflow-hidden"
+          >
+            <img 
+              :src="programDetail.company_logo" 
+              class="w-full h-full object-cover"
+              alt="企業 LOGO"
+            />
+          </div>
+          <div
+            v-else
             class="absolute left-6 top-6 flex h-16 w-16 items-center justify-center rounded-full border-2 border-gray-600 bg-white text-sm font-semibold text-gray-700"
           >
             LOGO
@@ -78,39 +169,41 @@ const onApplySubmitted = async () => {
           <h2
             class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-2xl font-bold text-gray-800"
           >
-            企業封面
+            {{ programDetail.name }}
           </h2>
 
           <!-- 公司名稱：可點擊前往公司詳情頁 -->
           <button
             type="button"
             class="absolute bottom-6 left-6 text-base font-medium text-primary-blue-dark hover:underline"
-            @click="navigateTo(userRoutes.companyDetail(companyId))"
+            @click="navigateTo(userRoutes.companyDetail(1))"
           >
-            {{ companyName }}
+            {{ programDetail.company_name }}
           </button>
         </div>
 
-        <!-- 軟體工程師一日體驗內容（與企業封面同區塊） -->
+        <!-- 計畫內容（與企業封面同區塊） -->
         <div class="mt-6 rounded-lg bg-white p-8 shadow-sm">
           <!-- 內容卡抬頭：左標題／右關鍵資訊 -->
           <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
             <div class="md:col-span-2">
-              <h3 class="text-xl font-bold">軟體工程師一日體驗營</h3>
-              <p class="mt-1 text-sm text-gray-500">科技業／軟體工程師</p>
+              <h3 class="text-xl font-bold">{{ programDetail.name }}</h3>
+              <p class="mt-1 text-sm text-gray-500">
+                {{ programDetail.Industry?.Title || '產業未分類' }}／{{ programDetail.JobTitle?.Title || '職位未分類' }}
+              </p>
             </div>
             <div class="flex flex-col gap-2 text-sm text-gray-600">
               <div class="flex items-center justify-between">
-                <span>已申請人數：0人</span>
-                <span>申請截止還有10天</span>
+                <span>已申請人數：{{ programDetail.applied_count }}人</span>
+                <span>申請截止還有{{ programDetail.days_left }}天</span>
               </div>
               <div class="flex items-center justify-between">
-                <span>招募天數：3天</span>
-                <span>招募人數：10-20人</span>
+                <span>招募天數：{{ programDetail.program_duration_days }}天</span>
+                <span>招募人數：{{ programDetail.min_people }}-{{ programDetail.max_people }}人</span>
               </div>
               <div class="flex items-center gap-2">
                 <font-awesome-icon :icon="['fas','calendar-alt']" />
-                <span>2025年10月15日 - 2025年10月17日</span>
+                <span>{{ formatDate(programDetail.program_start_date) }} - {{ formatDate(programDetail.program_end_date) }}</span>
               </div>
             </div>
           </div>
@@ -121,7 +214,7 @@ const onApplySubmitted = async () => {
             <section>
               <h4 class="mb-3 text-lg font-bold">體驗介紹</h4>
               <p class="leading-7">
-                目具文化探索交流帶您深入了解台灣新世代文化與自然景觀。在活動當中，您將有機會參與實務教學課程、參與團隊站會、系統設計與程式實作，並透過講師經歷穿針引線，掌握基礎的全貌與軟體文化切面，藉此獲得更多的職涯靈感。
+                {{ programDetail.intro }}
               </p>
             </section>
 
@@ -187,20 +280,23 @@ const onApplySubmitted = async () => {
           <!-- 標題 + 流程列表 -->
           <div class="mb-6">
             <h3 class="mb-4 text-lg font-bold">體驗流程</h3>
-            <dl class="space-y-4">
-              <div v-for="(s, idx) in flowSteps" :key="idx" class="grid grid-cols-12 gap-4">
-                <dt class="col-span-12 font-semibold text-gray-700 md:col-span-2">{{ s.label }}</dt>
+            <dl v-if="programDetail.Steps && programDetail.Steps.length > 0" class="space-y-4">
+              <div v-for="(step, idx) in programDetail.Steps" :key="idx" class="grid grid-cols-12 gap-4">
+                <dt class="col-span-12 font-semibold text-gray-700 md:col-span-2">{{ step.Name }}</dt>
                 <dd class="col-span-12 leading-7 text-gray-700 md:col-span-10">
-                  {{ s.text }}
+                  {{ step.Description }}
                 </dd>
               </div>
             </dl>
+            <div v-else class="text-gray-500 text-center py-8">
+              暫無體驗流程資訊
+            </div>
           </div>
 
           <!-- 體驗地點 + 地圖 -->
           <div>
             <h3 class="mb-2 text-lg font-bold">體驗地點</h3>
-            <p class="mb-4 text-gray-700">{{ venue }}</p>
+            <p class="mb-4 text-gray-700">{{ programDetail.address }}</p>
             <div class="flex h-80 w-full items-center justify-center rounded bg-gray-300 text-3xl text-gray-700">
               地圖
             </div>
@@ -212,17 +308,26 @@ const onApplySubmitted = async () => {
       <section aria-label="體驗照片" class="mb-8">
         <div class="rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
           <h3 class="mb-6 text-lg font-bold">體驗照片</h3>
-          <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-            <div v-for="photo in galleryPhotos" :key="photo.id" class="rounded bg-gray-300">
-              <!-- 若未提供圖片，顯示佔位；未來可改成 <img :src="photo.src" :alt="photo.alt" class="h-48 w-full object-cover rounded" /> -->
-              <div class="flex h-48 w-full items-center justify-center text-3xl text-gray-700">
+          <div v-if="programDetail.Images && programDetail.Images.length > 0" class="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <div v-for="(image, idx) in programDetail.Images" :key="idx" class="rounded bg-gray-300">
+              <img 
+                v-if="image" 
+                :src="image" 
+                :alt="`體驗照片 ${idx + 1}`" 
+                class="h-48 w-full object-cover rounded"
+              />
+              <div v-else class="flex h-48 w-full items-center justify-center text-3xl text-gray-700">
                 圖片
               </div>
             </div>
           </div>
+          <div v-else class="text-gray-500 text-center py-8">
+            暫無體驗照片
+          </div>
         </div>
       </section>
     </div>
+  </div>
   </main>
   <el-dialog
     v-model="showApply"

--- a/project-steps.md
+++ b/project-steps.md
@@ -78,3 +78,18 @@
 - 修改 `useUserPrograms.ts` 的錯誤處理機制，針對 401 未授權錯誤提供友善的降級處理，避免因認證問題阻擋資料顯示。
 - 更新頁面資料獲取邏輯，移除登入狀態檢查，確保分頁、篩選等功能對所有用戶開放，提升頁面可用性與用戶體驗。
 
+### 2025-08-29
+#### 體驗者端-單一計畫頁 (u-users-5)
+- 建立 `types/users/programDetail.ts` 型別，定義單一計畫回應結構。
+- 建立 `useUserProgramDetail.ts` composable 與 `useUserProgramDetailStore.ts` store，封裝詳情 API 與 loading/error 狀態。
+- 重構 `pages/users/programs/[programId].vue` 使用 store 資料渲染，加入 Skeleton 載入元件與共用錯誤元件（顯示於內容區域）。
+- 實作列表頁到詳情頁的邏輯鍊條：在 `pages/users/index.vue` 點擊卡片時先取詳情並再導頁。
+- 嚴格解析 program 主鍵 Id，避免將 `ApplicationId` 誤當成 `programId` 導致 404。
+- 加入 dev 環境 fallback 流程：當缺少 `programId` 時以測試 Id `45` 取代並繼續流程（正式環境不啟用）。
+- 將原本以 `ElMessage` 呈現的提示改為 `console.log` 紀錄，避免展示環境的視覺干擾。
+
+#### 體驗者端-清單與型別強化
+- 正規化清單資料 Id 欄位（優先 `Program.Id` → `Id`/`id`），為詳情導頁建立穩健基礎。
+- 修復熱門排序的可能 `Score` 空值問題，改用 `(Score ?? 0)`，移除 TypeScript 警告。
+- 收斂 API 錯誤型別，對 `apiError.value` 進行窄化，避免 `data`/`message` 屬性不存在的型別錯誤。
+

--- a/stores/user/useUserProgramDetailStore.ts
+++ b/stores/user/useUserProgramDetailStore.ts
@@ -1,0 +1,101 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import type { ProgramDetail } from '~/types/users/programDetail';
+import { useUserProgramDetail } from '~/composables/api/users/useUserProgramDetail';
+
+export const useUserProgramDetailStore = defineStore('userProgramDetail', () => {
+  // State
+  const programDetail = ref<ProgramDetail | null>(null);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+  const currentProgramId = ref<string | number | null>(null);
+
+  // Computed
+  const hasData = computed(() => programDetail.value !== null);
+  const hasError = computed(() => error.value !== null);
+
+  // API
+  const { fetchProgramDetail } = useUserProgramDetail();
+
+  /**
+   * 取得計畫詳情
+   * @param programId 計畫 ID
+   */
+  const fetchDetail = async (programId: string | number) => {
+    try {
+      // 如果已經載入過相同 ID 的資料，直接返回
+      if (currentProgramId.value === programId && programDetail.value) {
+        console.log('Program detail already loaded, returning cached data');
+        return programDetail.value;
+      }
+
+      loading.value = true;
+      error.value = null;
+      currentProgramId.value = programId;
+
+      console.log('Fetching program detail for ID:', programId);
+
+      const detail = await fetchProgramDetail(programId);
+      if (!detail) throw new Error('無效的 API 回應格式');
+      programDetail.value = detail;
+      console.log('Program detail loaded successfully:', detail);
+    } catch (err) {
+      console.error('Error in fetchDetail:', err);
+      
+      // 根據錯誤類型設定不同的錯誤訊息
+      if (err instanceof Error) {
+        if (err.message.includes('404') || err.message.includes('Not Found')) {
+          error.value = '找不到指定的體驗計畫，可能已被移除或不存在。';
+        } else if (err.message.includes('401') || err.message.includes('Unauthorized')) {
+          error.value = '您沒有權限查看此計畫，請確認登入狀態。';
+        } else if (err.message.includes('500') || err.message.includes('Internal Server Error')) {
+          error.value = '伺服器發生錯誤，請稍後再試。';
+        } else {
+          error.value = err.message || '載入計畫詳情時發生未知錯誤。';
+        }
+      } else {
+        error.value = '載入計畫詳情時發生未知錯誤。';
+      }
+      
+      // 清空資料
+      programDetail.value = null;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * 清空資料
+   */
+  const clearDetail = () => {
+    programDetail.value = null;
+    error.value = null;
+    currentProgramId.value = null;
+  };
+
+  /**
+   * 重新載入當前計畫詳情
+   */
+  const refreshDetail = async () => {
+    if (currentProgramId.value) {
+      await fetchDetail(currentProgramId.value);
+    }
+  };
+
+  return {
+    // State
+    programDetail,
+    loading,
+    error,
+    currentProgramId,
+    
+    // Computed
+    hasData,
+    hasError,
+    
+    // Actions
+    fetchDetail,
+    clearDetail,
+    refreshDetail,
+  };
+});

--- a/ticket.md
+++ b/ticket.md
@@ -1,0 +1,29 @@
+## u-users-5 單一計畫頁 Fallback 問題紀錄 — 2025-08-29
+
+- **問題摘要**: 列表 API `GET /api-proxy/v1/users/programs` 回傳的每筆 item 只有 `ApplicationId`，缺少可供詳情 API 使用的真正 `program_id`（`Id`/`Program.Id` 皆為空）。因此從列表點擊「查看詳情」時，若誤用 `ApplicationId`（例如 22）請求 `GET /api-proxy/v1/programs/{id}` 會得到 404。
+
+- **發現時機點**: 體驗者首頁 `pages/users/index.vue` 點擊卡片「查看詳情」後，詳情請求返回 404。
+
+- **發現位置、發現方式**: 於瀏覽器開發者工具 Network 面板觀察到請求 `/api-proxy/v1/programs/22` 404；同時在 Console 看到我們加的 `Invalid programId provided...` 紀錄。
+
+- **如何發現的？**: 比對 Postman 成功案例 `GET /api/v1/programs/45` 與前端實際送出的 id（22），確認列表 API 缺少真正的 `program_id`，導致路由至不存在的資源。
+
+- **前端測試了哪些面向？用什麼方法測試？**
+  - 點擊首頁 6 張卡片逐一驗證請求 id 與回應狀態（Network）。
+  - 以 console 紀錄 `program.Id`/`Program.Id` 解析結果與實際請求路徑。
+  - 驗證詳情頁 skeleton 載入、錯誤元件顯示與 store 流程（`useUserProgramDetailStore`）。
+  - 交叉驗證 Postman 詳情 API（id=45）可成功取得資料。
+
+- **對使用者影響**: 使用者從列表進入詳情會失敗，流程被中斷並造成困惑；目前僅在開發環境以 fallback 減緩，正式環境仍會受影響。
+
+- **如何定位問題屬於前端或後端？**: 詳情 API 需要 `program_id`，而列表 API 未提供；以 `ApplicationId` 呼叫詳情將必然 404。屬於後端 API 合約/資料缺漏。
+
+- **本次問題受影響範圍？**: 體驗者首頁列表 → 詳情導頁；後續依賴 `program_id` 的功能（收藏、申請、分享、統計）皆可能受阻。
+
+- **目前臨時應對方案？**: 前端在 dev 模式導入 fallback（`program_id=45`），缺少 `programId` 時以之替代以利驗證流程；同時以 `console.log` 輕量提示，不干擾展示。
+
+- **未來完整處理方案？**
+  - 後端：於列表 API item 中提供真正的主鍵 `program_id`（建議欄位 `id` 或 `Program: { Id }`），或提供橋接端點 `/v1/users/applications/{applicationId}` 以換取 `programId`。
+  - 前端：移除 fallback，改以列表回傳的 `program_id` 正常導頁；維持 id 正規化與錯誤防護；補充 E2E/整合測試覆蓋卡片→詳情全流程。
+
+

--- a/types/users/programDetail.ts
+++ b/types/users/programDetail.ts
@@ -1,0 +1,89 @@
+// 單一計畫詳情的型別定義
+// 基於 API response body 結構
+
+export interface CompanyInfo {
+  company_name: string;
+  company_logo: string;
+  company_cover: string;
+}
+
+export interface IndustryInfo {
+  Id: number;
+  Title: string;
+}
+
+export interface JobTitleInfo {
+  Id: number;
+  Title: string;
+}
+
+export interface StatusInfo {
+  Id: number;
+  Title: string;
+}
+
+export interface ProgramStep {
+  Name: string;
+  Description: string;
+}
+
+export interface ProgramDetail {
+  // 公司相關資訊
+  company_name: string;
+  company_logo: string;
+  company_cover: string;
+  
+  // 計畫基本資訊
+  name: string;
+  intro: string;
+  industry_id: number;
+  job_title_id: number;
+  
+  // 地點資訊
+  address: string;
+  address_map: string | null;
+  
+  // 聯絡資訊
+  contact_name: string;
+  contact_phone: string;
+  contact_email: string;
+  
+  // 人數限制
+  min_people: number;
+  max_people: number;
+  
+  // 發布相關日期
+  publish_start_date: string;
+  publish_duration_days: number;
+  publish_end_date: string;
+  
+  // 計畫執行日期
+  program_start_date: string;
+  program_end_date: string;
+  program_duration_days: number;
+  
+  // 狀態資訊
+  status_id: number;
+  status_title: string | null;
+  
+  // 申請相關
+  applied_count: number;
+  days_left: number;
+  is_ongoing: boolean | null;
+  
+  // 關聯物件
+  Industry: IndustryInfo;
+  JobTitle: JobTitleInfo;
+  Status: StatusInfo;
+  
+  // 圖片與步驟
+  Images: string[];
+  Steps: ProgramStep[];
+}
+
+// API 回應的型別
+export interface ProgramDetailResponse {
+  data: ProgramDetail;
+  message?: string;
+  success?: boolean;
+}


### PR DESCRIPTION
### 2025-08-29
#### 體驗者端-單一計畫頁 (u-users-5)
- 建立 `types/users/programDetail.ts` 型別，定義單一計畫回應結構。
- 建立 `useUserProgramDetail.ts` composable 與 `useUserProgramDetailStore.ts` store，封裝詳情 API 與 loading/error 狀態。
- 重構 `pages/users/programs/[programId].vue` 使用 store 資料渲染，加入 Skeleton 載入元件與共用錯誤元件（顯示於內容區域）。
- 實作列表頁到詳情頁的邏輯鍊條：在 `pages/users/index.vue` 點擊卡片時先取詳情並再導頁。
- 嚴格解析 program 主鍵 Id，避免將 `ApplicationId` 誤當成 `programId` 導致 404。
- 加入 dev 環境 fallback 流程：當缺少 `programId` 時以測試 Id `45` 取代並繼續流程（正式環境不啟用）。
- 將原本以 `ElMessage` 呈現的提示改為 `console.log` 紀錄，避免展示環境的視覺干擾。

#### 體驗者端-清單與型別強化
- 正規化清單資料 Id 欄位（優先 `Program.Id` → `Id`/`id`），為詳情導頁建立穩健基礎。
- 修復熱門排序的可能 `Score` 空值問題，改用 `(Score ?? 0)`，移除 TypeScript 警告。
- 收斂 API 錯誤型別，對 `apiError.value` 進行窄化，避免 `data`/`message` 屬性不存在的型別錯誤。