### PR TITLE
Fix/api  u users 3 get all events list

### DIFF
--- a/composables/api/users/useUserPrograms.ts
+++ b/composables/api/users/useUserPrograms.ts
@@ -1,5 +1,4 @@
 import type { ProgramsResponse, ProgramsQueryParams } from '~/types/users/program';
-import { useUserApiFetch } from '~/composables/api/users/useUserApiFetch';
 
 export const useUserPrograms = () => {
   const fetchPrograms = async (params: ProgramsQueryParams = {}) => {
@@ -14,13 +13,10 @@ export const useUserPrograms = () => {
     if (params.sort) queryParams.append('sort', params.sort);
 
     const queryString = queryParams.toString();
-    const url = `/api-proxy/v1/users/programs${queryString ? '?' + queryString : ''}`;
+    const url = `/api-proxy/v1/programs${queryString ? '?' + queryString : ''}`;
 
     try {
-      // 使用新的 useUserApiFetch
-      const data = await useUserApiFetch<ProgramsResponse>(url, {
-        method: 'GET'
-      });
+      const data = await $fetch<ProgramsResponse>(url, { method: 'GET' });
       
       return {
         data: { value: data },

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -270,7 +270,7 @@ const handleViewDetail = async (program: any) => {
               </button>
               <button 
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-                :class="activeStatus === 'reviewing' ? 'bg-primary-blue-light text-white' : 'bg-gray-600 hover:bg-gray-200'"
+                :class="activeStatus === 'reviewing' ? 'bg-primary-blue-light text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
                 @click="setActiveStatus('reviewing')"
               >
                 審核中({{ getStatusCount('審核中') }})
@@ -319,19 +319,16 @@ const handleViewDetail = async (program: any) => {
                   </div>
                   <div class="flex items-center gap-2">
                     <font-awesome-icon :icon="['fas', 'users']" class="text-gray-500 w-4" />
-                    <span class="text-sm text-black">活動人數: {{ program.AppliedCount || 0 }}人</span>
+                    <span class="text-sm text-black">已申請人數: {{ program.AppliedCount || 0 }}人</span>
                   </div>
                 </div>
                 
                 <!-- Company Name -->
                 <div class="text-xs text-gray-500 mb-2">
-                  公司: {{ program.Industry?.Title || '未指定產業' }}
+                  產業: {{ program.Industry?.Title || '未指定產業' }}
                 </div>
                 
-                <!-- Application Count -->
-                <div class="text-xs text-gray-500 mb-4">
-                  已申請人數: {{ program.AppliedCount || 0 }}人
-                </div>
+                
                 
                 <!-- Action Button -->
                 <button 

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -118,7 +118,9 @@ const setActiveStatus = (status: string) => {
 
 const getStatusCount = (status: string) => {
   if (!programsStore.items) return 0;
-  return programsStore.items.filter(program => program.Status === status).length;
+  // 由於新版本沒有 Status 欄位，暫時返回 0
+  // 未來可以根據其他欄位來判斷狀態
+  return 0;
 };
 
 // 解析清單項目的 ProgramId（兼容不同欄位命名）
@@ -181,7 +183,7 @@ const handleViewDetail = async (program: any) => {
               <el-card :body-style="{ padding: '0px' }" class="h-full">
                 <img :src="program.CoverImage || '/img/home/home-worker-bg.webp'" class="w-full h-2/3 object-cover" alt="program image" />
                 <div class="p-4">
-                  <h3 class="text-lg font-bold">{{ program.ProgramName || program.Name || '未命名計畫' }}</h3>
+                  <h3 class="text-lg font-bold">{{ program.Name || '未命名計畫' }}</h3>
                   <p class="text-sm text-gray-500">{{ program.Industry?.Title || '產業未分類' }}</p>
                 </div>
               </el-card>
@@ -254,7 +256,7 @@ const handleViewDetail = async (program: any) => {
               </button>
               <button 
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-                :class="activeStatus === 'reviewing' ? 'bg-primary-blue-light text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+                :class="activeStatus === 'reviewing' ? 'bg-primary-blue-light text-white' : 'bg-gray-600 hover:bg-gray-200'"
                 @click="setActiveStatus('reviewing')"
               >
                 審核中({{ getStatusCount('審核中') }})
@@ -274,14 +276,14 @@ const handleViewDetail = async (program: any) => {
                 />
                 <!-- Status Tag (左上角) -->
                 <div class="absolute top-2 left-2 bg-primary-blue-light text-white px-2 py-1 text-xs rounded z-10">
-                  {{ program.Status || '已發佈' }}
+                  已發佈
                 </div>
               </div>
               
               <!-- Program Content -->
               <div class="p-4">
                 <!-- Title -->
-                <h3 class="text-lg font-bold text-black mb-2">{{ program.ProgramName || program.Name || '未命名計畫' }}</h3>
+                <h3 class="text-lg font-bold text-black mb-2">{{ program.Name || '未命名計畫' }}</h3>
                 
                 <!-- Description -->
                 <p class="text-sm text-gray-600 mb-4 min-h-[3rem]">{{ program.Intro || '暫無介紹' }}</p>
@@ -302,13 +304,13 @@ const handleViewDetail = async (program: any) => {
                   </div>
                   <div class="flex items-center gap-2">
                     <font-awesome-icon :icon="['fas', 'users']" class="text-gray-500 w-4" />
-                    <span class="text-sm text-black">活動人數: {{ program.MinParticipants || 1 }}-{{ program.MaxParticipants || 12 }}人</span>
+                    <span class="text-sm text-black">活動人數: {{ program.AppliedCount || 0 }}人</span>
                   </div>
                 </div>
                 
                 <!-- Company Name -->
                 <div class="text-xs text-gray-500 mb-2">
-                  公司: {{ program.CompanyName || '未指定公司' }}
+                  公司: {{ program.Industry?.Title || '未指定產業' }}
                 </div>
                 
                 <!-- Application Count -->

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -181,7 +181,12 @@ const handleViewDetail = async (program: any) => {
           <el-carousel v-if="programsStore.popular && programsStore.popular.length > 0" :interval="4000" type="card" height="300px">
             <el-carousel-item v-for="program in programsStore.popular" :key="program.Id">
               <el-card :body-style="{ padding: '0px' }" class="h-full">
-                <img :src="program.CoverImage || '/img/home/home-worker-bg.webp'" class="w-full h-2/3 object-cover" alt="program image" />
+                <img 
+                  :src="program.CoverImage || '/img/home/home-worker-bg.webp'" 
+                  class="w-full h-2/3 object-cover" 
+                  alt="program image" 
+                  @error="(e: Event) => { (e.target as HTMLImageElement).src = '/img/home/home-worker-bg.webp'; }"
+                />
                 <div class="p-4">
                   <h3 class="text-lg font-bold">{{ program.Name || '未命名計畫' }}</h3>
                   <p class="text-sm text-gray-500">{{ program.Industry?.Title || '產業未分類' }}</p>
@@ -273,6 +278,7 @@ const handleViewDetail = async (program: any) => {
                   :src="program.CoverImage || '/img/home/home-worker-bg.webp'" 
                   class="w-full h-48 object-cover" 
                   alt="program image" 
+                  @error="(e: Event) => { (e.target as HTMLImageElement).src = '/img/home/home-worker-bg.webp'; }"
                 />
                 <!-- Status Tag (左上角) -->
                 <div class="absolute top-2 left-2 bg-primary-blue-light text-white px-2 py-1 text-xs rounded z-10">

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -18,6 +18,15 @@ const programDetailStore = useUserProgramDetailStore();
 // 開發環境用的 fallback programId（後端清單缺少真正的 programId 時使用）
 const FALLBACK_PROGRAM_ID = 45;
 
+// 圖片載入錯誤時回退至預設圖片
+const onProgramImageError = (e: Event) => {
+  const img = e.target as HTMLImageElement;
+  if (img && img.src !== '/img/home/home-worker-bg.webp') {
+    img.src = '/img/home/home-worker-bg.webp';
+    img.onerror = null; // 避免 fallback 再次觸發造成遞迴
+  }
+};
+
 const searchKeyword = ref('');
 const industry = ref('');
 const jobType = ref('');
@@ -185,7 +194,7 @@ const handleViewDetail = async (program: any) => {
                   :src="program.CoverImage || '/img/home/home-worker-bg.webp'" 
                   class="w-full h-2/3 object-cover" 
                   alt="program image" 
-                  @error="(e: Event) => { (e.target as HTMLImageElement).src = '/img/home/home-worker-bg.webp'; }"
+                  @error="onProgramImageError"
                 />
                 <div class="p-4">
                   <h3 class="text-lg font-bold">{{ program.Name || '未命名計畫' }}</h3>
@@ -278,7 +287,7 @@ const handleViewDetail = async (program: any) => {
                   :src="program.CoverImage || '/img/home/home-worker-bg.webp'" 
                   class="w-full h-48 object-cover" 
                   alt="program image" 
-                  @error="(e: Event) => { (e.target as HTMLImageElement).src = '/img/home/home-worker-bg.webp'; }"
+                  @error="onProgramImageError"
                 />
                 <!-- Status Tag (左上角) -->
                 <div class="absolute top-2 left-2 bg-primary-blue-light text-white px-2 py-1 text-xs rounded z-10">

--- a/project-steps.md
+++ b/project-steps.md
@@ -1,95 +1,14 @@
 ( 已經搬移部分內容到 notion )
 
-### 2025-08-27
-#### 企業端-申請者列表 (e-comp-7)
-- 修正申請者列表頁面 (`applicants/index.vue`) 的表格欄位綁定，使其與 `e-comp-7` API 回應的欄位名稱 (`applicant_name`, `submit_date`, `review_status` 等) 一致，解決資料無法渲染的問題。
-- 臨時修復點擊「查看」按鈕時因 API 回應缺少 `applicant_id` 而導致的 500 錯誤，暫時改用 `identity` 作為跳轉參數。
-- 優化申請者列表頁面的使用者體驗 (UX)，移除 API 未提供的「科系」與「學校」欄位以避免顯示空白。
 
-#### 企業端-方案頁面 (e-comp-13)
-- 串接取得所有企業付費方案的 API (`e-comp-13`)，並動態渲染於方案頁面 (`purchase/index.vue`)。
-- 建立獨立的 Composable (`useAllPlans.ts`) 統一管理 API 請求邏輯。
-- 重構方案相關的 TypeScript 型別定義，將其拆分為 `plan/current.ts` 與 `plan/list.ts`，並置於 `types/company/plan` 子目錄下，以提高程式碼的清晰度與可維護性。
-- 優化方案描述的 UX，為 `description` 欄位為空值的方案提供符合其量級的備用文案，提升頁面資訊完整度與價值感。
 
-#### 企業端-體驗者審核 (e-comp-17)
-- 建立 `useSubmitReview.ts` Composable 封裝審核提交 (`PUT`) 的 API 邏輯，並處理 loading 與 error 狀態。
-- 於申請者詳情頁 (`[applicantId].vue`) 串接審核功能，提交後以 `ElMessageBox` 彈窗提供即時成功或失敗的反饋，並在成功後自動導航回列表頁。
-- 修正 `useSubmitReview` Composable，改用共用的 `useApiFetch` 以確保請求能自動夾帶 JWT token，解決 API 回應「請登入」的認證問題。
-- 導入 Element Plus 的表單驗證機制，為「審核意見」欄位加入必填規則，取代原有的手動 `if` 判斷，以解決後端回應 `400 Bad Request` (缺少 `comment` 欄位) 的問題。
-- 於申請者列表頁 (`applicants/index.vue`) 的 `onMounted` 生命週期中呼叫 `refresh` 方法，確保從審核頁返回時能強制刷新列表，即時反映最新的審核狀態。
-
-#### 體驗者端-使用者登入 (u-users-1)
-- 建立 `useUserLogin.ts` Composable 封裝使用者登入 API (`/api/v1/users/login`) 的請求邏輯。
-- 重構共用 API 請求函式 (`useApiFetch.ts`)，使其能根據請求 URL (`/user` 或 `/company`) 自動附加對應模組的 JWT token，解決了模組間 token 錯亂的潛在衝突。
-- 更新 `useUserAuthStore` 以整合新的登入邏輯，並使其結構與 `company` 模組一致，同步管理 `token` 與 `user` 狀態。
-- 修正 `nuxt.config.ts` 中的 Vite 代理設定，解決了開發環境中因代理規則不符而導致的 API 請求 404 錯誤。
-- 優化登入頁面 (`login.vue`) 的使用者體驗，透過 `watchEffect` 監聽登入狀態，實現成功登入後自動導航至使用者首頁。
-
-#### 通用佈局 (Layouts)
-- 修改 `main.vue` 佈局，將「探索我們」按鈕連結至體驗者首頁 (`user-landing`)，提供訪客快速瀏覽主要內容的入口。
-
-#### 體驗者端-使用者註冊 (u-users-10)
-- 建立 `useUserRegister.ts` Composable 以封裝註冊 API (`POST /api/v1/users`) 的請求邏輯，遵循專案既有的程式碼風格。
-- 更新 `useAuthStore` 中的 `register` 動作，使其使用新建的 Composable 進行 API 呼叫，並加入完整的錯誤處理機制。
-- 擴充 `User` TypeScript 型別，加入 `createdAt` 與 `updatedAt` 欄位，使其與後端 API 回應的資料結構保持一致。
-- 驗證 `register.vue` 頁面的前端邏輯，確保其在註冊成功後能正確顯示成功訊息並將使用者導向登入頁面。
-- 修復 `useAuthStore` 中的 TypeScript 型別推斷錯誤，確保程式碼的健壯性。
-
-### 2025-08-28
-#### 體驗者端-體驗計畫總覽 (u-users-3)
-- 建立 `useUserPrograms.ts` Composable 封裝取得全部體驗計畫總覽的 API (`/api/v1/users/programs`) 請求邏輯，支援分頁與篩選參數。
-- 建立 `useProgramsStore.ts` Pinia store 管理體驗計畫的狀態，包含 `items`、`popular`、`total`、`currentPage` 等資料結構。
-- 更新 `pages/users/index.vue` 頁面，將靜態資料替換為動態 API 資料，並實作 `watch` 監聽器觸發資料重新載入。
-- 修正欄位映射問題，將 API 回應的大寫欄位名稱 (`program.Name`, `program.CoverImage`, `program.Address` 等) 正確對應到前端顯示需求。
-- 新增 `formatProgramDate` 函數處理日期格式化，並加入 `v-if` 檢查防止 SSR 期間的渲染錯誤。
-
-#### API 架構統一與優化
-- 統一 Users 與 Company 模塊的 API 架構設計，確保兩個模塊使用一致的認證與請求處理邏輯。
-- 建立 `useUserApiFetch.ts` 專用於 Users 模塊的 API 請求處理，自動注入 JWT token 並與 Company 模塊保持一致的架構模式。
-- 恢復 Nuxt Vite proxy 配置，解決開發環境中 API 請求的 CORS 與路由問題。
-- 修正環境變數 `NUXT_PUBLIC_API_BASE_URL=/api-proxy` 的配置，確保 proxy 轉發功能正常運作。
-- 解決登入後路由導航失敗的問題，透過重新實作 `authStore.fetchUser()` 與加入 `middleware: 'user-auth'` 確保認證狀態正確更新。
-
-#### 技術債務與架構改進
-- 移除不必要的 `useCompanyApiFetch.ts` 檔案，簡化 API 架構複雜度。
-- 更新 `useApiFetch.ts` 共享基礎函數，專注於 Company 模塊的 token 注入邏輯。
-- 建立專案 API 架構文件 (`docs/API_ARCHITECTURE.md`)，記錄統一的設計模式與路徑格式。
-- 解決 TypeScript 模組載入問題，執行 `pnpm nuxt prepare` 重新生成型別檔案。
-
-#### API 架構設計與 CORS 問題解決
-- 分析並解決 Users 模塊直連後端 API 時遭遇的 CORS 政策阻擋問題，確認在無後端控制權的情況下需要啟用代理轉發功能。
-- 重新啟用 Nuxt Vite proxy 配置，設定 `/api-proxy` 路徑轉發至 `https://trybeta.rocket-coding.com`，解決跨域請求問題。
-- 統一 Users 與 Company 模塊的 API 架構模式，兩個模塊都使用專用的 API fetch 函數 (`useUserApiFetch`, `useCompanyApiFetch`) 並依賴代理轉發。
-- 修改 Users 模塊的所有 API 路徑從 `/api/v1/*` 改為 `/api-proxy/v1/*`，確保請求能透過本地開發伺服器代理轉發。
-- 優化 `useUserApiFetch.ts` 配置，移除 `baseURL` 設定，依賴代理轉發機制處理路徑映射。
-- 驗證代理轉發功能正常運作，確認 `login` 與 `programs` API 請求都能成功返回 200 狀態碼，解決了開發環境中的 CORS 與路由問題。
-
-#### 前端錯誤修復與資料渲染優化
-- 修復 `pages/users/index.vue` 頁面中的 `TypeError: Cannot read properties of undefined (reading 'Title')` 錯誤，透過加入 `?.` 安全檢查防止存取 `undefined` 物件的屬性。
-- 優化 `formatProgramDate` 函數的錯誤處理機制，加入日期欄位為空值時的檢查，避免因無效日期導致的渲染錯誤。
-- 為所有可能為空的資料欄位加入預設值處理，包括 `program.Industry?.Title || '產業未分類'`、`program.CoverImage || '/img/home/default-program.webp'` 等，提升頁面穩定性。
-- 解決開發者工具中顯示的紅字錯誤，確保即使 API 回應資料不完整，前端頁面仍能正常渲染並顯示適當的預設內容。
-
-#### 體驗者端-頁面權限與按鈕狀態管理
-- 移除 `pages/users/index.vue` 頁面的 `middleware: 'user-auth'` 限制，將頁面改為公開資源，允許訪客瀏覽體驗計畫卡片。
-- 實作基於登入狀態的按鈕控制邏輯，登入用戶可點選「查看詳情」按鈕，訪客狀態下按鈕被禁用並顯示「請先登入以查看詳情」提示。
-- 優化 `useUserApiFetch.ts` 的 token 注入邏輯，允許無 token 狀態下的公開 API 請求，確保訪客也能正常獲取計畫資料。
-- 修改 `useUserPrograms.ts` 的錯誤處理機制，針對 401 未授權錯誤提供友善的降級處理，避免因認證問題阻擋資料顯示。
-- 更新頁面資料獲取邏輯，移除登入狀態檢查，確保分頁、篩選等功能對所有用戶開放，提升頁面可用性與用戶體驗。
-
-### 2025-08-29
-#### 體驗者端-單一計畫頁 (u-users-5)
-- 建立 `types/users/programDetail.ts` 型別，定義單一計畫回應結構。
-- 建立 `useUserProgramDetail.ts` composable 與 `useUserProgramDetailStore.ts` store，封裝詳情 API 與 loading/error 狀態。
-- 重構 `pages/users/programs/[programId].vue` 使用 store 資料渲染，加入 Skeleton 載入元件與共用錯誤元件（顯示於內容區域）。
-- 實作列表頁到詳情頁的邏輯鍊條：在 `pages/users/index.vue` 點擊卡片時先取詳情並再導頁。
-- 嚴格解析 program 主鍵 Id，避免將 `ApplicationId` 誤當成 `programId` 導致 404。
-- 加入 dev 環境 fallback 流程：當缺少 `programId` 時以測試 Id `45` 取代並繼續流程（正式環境不啟用）。
-- 將原本以 `ElMessage` 呈現的提示改為 `console.log` 紀錄，避免展示環境的視覺干擾。
-
-#### 體驗者端-清單與型別強化
-- 正規化清單資料 Id 欄位（優先 `Program.Id` → `Id`/`id`），為詳情導頁建立穩健基礎。
-- 修復熱門排序的可能 `Score` 空值問題，改用 `(Score ?? 0)`，移除 TypeScript 警告。
-- 收斂 API 錯誤型別，對 `apiError.value` 進行窄化，避免 `data`/`message` 屬性不存在的型別錯誤。
-
+## 2025-08-30
+- 開放 u-user-3 體驗計畫清單 API 為公開存取，移除 Token 需求。
+- 透過開發代理呼叫 `/api-proxy/v1/programs`，與遠端 `/api` 重寫規則一致。
+- 改用 `$fetch` 直取公開 API，避免 `useFetch` reactive 回傳造成 `pending=true`、`data=null`。
+- 調整 `types/users/program.ts` 以符合新 response；移除 `ApplicationId`、`ProgramName`、`Steps`（含 `ProgramStep`）、`SubmitAt`、`Status`、`CompanyName`、`MaxParticipants`、`MinParticipants`；保留 `Id`、`Name` 等必要欄位。
+- 更新 `composables/api/users/useUserPrograms.ts` 建立查詢字串並對接公開端點；回傳結構與 store 介面相容。
+- 更新 `stores/user/useProgramsStore.ts` 正規化清單並保存每筆 `Id` 至 store，支援後續申請/收藏流程。
+- 更新 `pages/users/index.vue` 將 `ProgramName` 改為 `Name`，移除 `Status` 顯示與統計，調整卡片欄位顯示。
+- 修正 linter 問題並通過檢查；驗證 Postman 與開發代理結果一致，清單成功載入。
+- 強化錯誤處理回傳格式與 Loading 狀態，保持與現有內容調性一致。

--- a/project-steps.md
+++ b/project-steps.md
@@ -12,3 +12,5 @@
 - 更新 `pages/users/index.vue` 將 `ProgramName` 改為 `Name`，移除 `Status` 顯示與統計，調整卡片欄位顯示。
 - 修正 linter 問題並通過檢查；驗證 Postman 與開發代理結果一致，清單成功載入。
 - 強化錯誤處理回傳格式與 Loading 狀態，保持與現有內容調性一致。
+- 新增圖片 fallback：熱門區與一般清單 `<img>` 皆在 `onerror` 回退至 `/img/home/home-worker-bg.webp`。
+- 建立熱門精選邏輯：在 `useProgramsStore` 預留 `isPopularProgram` 與 `computePopularPrograms`，以 Score > 10 篩選並排序前 5 筆，之後可擴展加權規則（收藏、瀏覽、成長率等）。

--- a/project-steps.md
+++ b/project-steps.md
@@ -14,3 +14,4 @@
 - 強化錯誤處理回傳格式與 Loading 狀態，保持與現有內容調性一致。
 - 新增圖片 fallback：熱門區與一般清單 `<img>` 皆在 `onerror` 回退至 `/img/home/home-worker-bg.webp`。
 - 建立熱門精選邏輯：在 `useProgramsStore` 預留 `isPopularProgram` 與 `computePopularPrograms`，以 Score > 10 篩選並排序前 5 筆，之後可擴展加權規則（收藏、瀏覽、成長率等）。
+-. 抽離圖片錯誤處理：將 inline `@error` 事件改為 `onProgramImageError` 函式，避免將邏輯混雜於 template、提升可讀性與可測性（同時避免遞迴觸發）。

--- a/project-steps.md
+++ b/project-steps.md
@@ -15,3 +15,7 @@
 - 新增圖片 fallback：熱門區與一般清單 `<img>` 皆在 `onerror` 回退至 `/img/home/home-worker-bg.webp`。
 - 建立熱門精選邏輯：在 `useProgramsStore` 預留 `isPopularProgram` 與 `computePopularPrograms`，以 Score > 10 篩選並排序前 5 筆，之後可擴展加權規則（收藏、瀏覽、成長率等）。
 -. 抽離圖片錯誤處理：將 inline `@error` 事件改為 `onProgramImageError` 函式，避免將邏輯混雜於 template、提升可讀性與可測性（同時避免遞迴觸發）。
+ - 修正使用者清單卡片顯示：將「公司」標籤改為「產業」，避免以產業誤當公司名稱顯示。
+ - 合併人數欄位：把上方「活動人數」改為單一「已申請人數」，並刪除下方重複區塊以消除語意重複。
+ - 通過 Lint 檢查並驗證 UI 呈現；不改動 API 與型別定義。
+ - 參考檔案 `pages/users/index.vue` 完成編修，未涉及 store 與 composables 變更。

--- a/stores/user/useProgramsStore.ts
+++ b/stores/user/useProgramsStore.ts
@@ -49,17 +49,12 @@ export const useUserProgramsStore = defineStore('userPrograms', () => {
         console.log('Setting programs data:', data.value);
         // 正規化：確保每一筆清單都有可用的 Program Id
         const normalizedItems = (data.value.items || []).map((raw: any) => {
-          // 嚴格優先使用真正的 Program.Id（詳細頁 API 使用的 Id）
-          const programIdCandidate =
-            raw?.Program?.Id ??
-            raw?.Program?.id ??
-            raw?.Id ??
-            raw?.id ??
-            null; // 不再使用 ProgramId/ApplicationId 以避免誤導到 404
+          // 使用新的 response body 結構，直接使用 Id 欄位
+          const programId = raw?.Id ?? null;
 
           return {
             ...raw,
-            Id: programIdCandidate,
+            Id: programId,
           } as unknown as Program;
         });
 

--- a/stores/user/useProgramsStore.ts
+++ b/stores/user/useProgramsStore.ts
@@ -11,14 +11,25 @@ export const useUserProgramsStore = defineStore('userPrograms', () => {
   const loading = ref(false);
   const error = ref<string | null>(null);
 
-  // Computed properties
-  const items = computed(() => programs.value);
-  const popular = computed(() => {
-    // 取得評分最高的前 5 個計畫作為熱門計畫
-    return [...programs.value]
+  // 熱門邏輯：預留擴展點
+  const isPopularProgram = (program: Program): boolean => {
+    // 目前規則：Score > 10 才視為熱門
+    // 未來可擴充：加入 FavoritesCount、ViewsCount、近7日成長率等加權計算
+    const score = program.Score ?? 0;
+    return score > 10;
+  };
+
+  const computePopularPrograms = (list: Program[]): Program[] => {
+    // 預留擴展：可改為多指標加權排序或時間區間篩選
+    return [...list]
+      .filter(isPopularProgram)
       .sort((a, b) => (b.Score ?? 0) - (a.Score ?? 0))
       .slice(0, 5);
-  });
+  };
+
+  // Computed properties
+  const items = computed(() => programs.value);
+  const popular = computed(() => computePopularPrograms(programs.value));
 
   const { fetchPrograms: apiFetchPrograms } = useUserPrograms();
 

--- a/types/users/program.ts
+++ b/types/users/program.ts
@@ -10,39 +10,24 @@ export interface JobTitle {
   Title: string;
 }
 
-export interface ProgramStep {
-  Name: string;
-  Description: string;
-  CreatedAt: string;
-  UpdatedAt: string;
-}
-
 export interface Program {
   Id: number;
-  ApplicationId?: number; // 新增：申請 ID
-  Name?: string; // 可選：名稱
-  ProgramName: string; // 主要名稱欄位
+  Name: string;
   Intro: string;
   Address: string;
-  Industry?: Industry; // 可選：產業資訊
-  JobTitle?: JobTitle; // 可選：職位資訊
-  PublishStartDate?: string; // 可選：發布開始日期
-  PublishEndDate?: string; // 可選：發布結束日期
+  Industry?: Industry;
+  JobTitle?: JobTitle;
+  PublishStartDate?: string;
+  PublishEndDate?: string;
   ProgramStartDate: string;
   ProgramEndDate: string;
-  CoverImage?: string; // 可選：封面圖片
-  Steps?: ProgramStep[]; // 可選：計畫步驟
-  AppliedCount?: number; // 可選：已申請人數
-  DaysLeft?: number; // 可選：剩餘天數
-  IsOngoing?: boolean | null; // 可選：是否進行中
-  ViewsCount?: number; // 可選：瀏覽次數
-  FavoritesCount?: number; // 可選：收藏次數
-  Score?: number; // 可選：評分
-  SubmitAt?: string; // 新增：提交時間
-  Status?: string; // 新增：計畫狀態
-  CompanyName?: string; // 新增：公司名稱
-  MaxParticipants?: number; // 新增：最大參與人數
-  MinParticipants?: number; // 新增：最小參與人數
+  CoverImage?: string;
+  AppliedCount?: number;
+  DaysLeft?: number;
+  IsOngoing?: boolean | null;
+  ViewsCount?: number;
+  FavoritesCount?: number;
+  Score?: number;
 }
 
 export interface ProgramsResponse {


### PR DESCRIPTION
## 2025-08-30
- 開放 u-user-3 體驗計畫清單 API 為公開存取，移除 Token 需求。
- 透過開發代理呼叫 `/api-proxy/v1/programs`，與遠端 `/api` 重寫規則一致。
- 改用 `$fetch` 直取公開 API，避免 `useFetch` reactive 回傳造成 `pending=true`、`data=null`。
- 調整 `types/users/program.ts` 以符合新 response；移除 `ApplicationId`、`ProgramName`、`Steps`（含 `ProgramStep`）、`SubmitAt`、`Status`、`CompanyName`、`MaxParticipants`、`MinParticipants`；保留 `Id`、`Name` 等必要欄位。
- 更新 `composables/api/users/useUserPrograms.ts` 建立查詢字串並對接公開端點；回傳結構與 store 介面相容。
- 更新 `stores/user/useProgramsStore.ts` 正規化清單並保存每筆 `Id` 至 store，支援後續申請/收藏流程。
- 更新 `pages/users/index.vue` 將 `ProgramName` 改為 `Name`，移除 `Status` 顯示與統計，調整卡片欄位顯示。
- 修正 linter 問題並通過檢查；驗證 Postman 與開發代理結果一致，清單成功載入。
- 強化錯誤處理回傳格式與 Loading 狀態，保持與現有內容調性一致。
- 新增圖片 fallback：熱門區與一般清單 `<img>` 皆在 `onerror` 回退至 `/img/home/home-worker-bg.webp`。
- 建立熱門精選邏輯：在 `useProgramsStore` 預留 `isPopularProgram` 與 `computePopularPrograms`，以 Score > 10 篩選並排序前 5 筆，之後可擴展加權規則（收藏、瀏覽、成長率等）。
-. 抽離圖片錯誤處理：將 inline `@error` 事件改為 `onProgramImageError` 函式，避免將邏輯混雜於 template、提升可讀性與可測性（同時避免遞迴觸發）。