### PR TITLE
feat(users): 對接 u-user-5 詳情 API、移除頁面 fallback、同步型別

### DIFF
--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -15,8 +15,7 @@ const authStore = useUserAuthStore();
 const programsStore = useUserProgramsStore();
 const programDetailStore = useUserProgramDetailStore();
 
-// 開發環境用的 fallback programId（後端清單缺少真正的 programId 時使用）
-const FALLBACK_PROGRAM_ID = 45;
+// 已移除開發環境用的 fallback programId，改以實際回傳的 Id 為準
 
 // 圖片載入錯誤時回退至預設圖片
 const onProgramImageError = (e: Event) => {
@@ -132,19 +131,9 @@ const getStatusCount = (status: string) => {
   return 0;
 };
 
-// 解析清單項目的 ProgramId（兼容不同欄位命名）
+// 解析清單項目的 ProgramId（以回傳的 Id 為主，保守兼容 id）
 const resolveProgramId = (program: any) => {
-  // 僅接受可用的 Program Id 欄位；不再使用 ApplicationId 以免誤傳
-  return (
-    program?.Id ??
-    program?.id ??
-    program?.ProgramId ??
-    program?.programId ??
-    program?.Program?.Id ??
-    program?.Program?.id ??
-    program?.ID ??
-    null
-  );
+  return program?.Id ?? program?.id ?? null;
 };
 
 // 處理查看詳情按鈕點擊
@@ -152,16 +141,8 @@ const handleViewDetail = async (program: any) => {
   try {
     const programId = resolveProgramId(program);
     if (programId === undefined || programId === null || programId === '') {
-      console.warn('Invalid programId provided to handleViewDetail:', program);
-      if (process.dev && FALLBACK_PROGRAM_ID) {
-        console.log(`[dev:fallback] 此卡片缺少 programId，改用 fallback=${FALLBACK_PROGRAM_ID}`);
-        await programDetailStore.fetchDetail(FALLBACK_PROGRAM_ID);
-        await navigateTo(userRoutes.programDetail(FALLBACK_PROGRAM_ID));
-        return;
-      } else {
-        console.log('[warn] 此體驗卡片缺少 programId，暫時無法查看詳情');
-        return;
-      }
+      console.warn('此體驗卡片缺少有效的 programId，暫時無法查看詳情');
+      return;
     }
     // 先取得計畫詳情
     await programDetailStore.fetchDetail(programId);

--- a/project-steps.md
+++ b/project-steps.md
@@ -19,3 +19,8 @@
  - 合併人數欄位：把上方「活動人數」改為單一「已申請人數」，並刪除下方重複區塊以消除語意重複。
  - 通過 Lint 檢查並驗證 UI 呈現；不改動 API 與型別定義。
  - 參考檔案 `pages/users/index.vue` 完成編修，未涉及 store 與 composables 變更。
+ - 移除 `pages/users/index.vue` 的開發用 fallback programId 與 dev 分支；`resolveProgramId` 收斂為 `Id ?? id`，全面以後端回傳 Id 為準。
+ - 對接詳情流程：按鈕「查看詳情」觸發 `handleViewDetail` → 呼叫 `useUserProgramDetailStore.fetchDetail(programId)` → 由 `composables/api/users/useUserProgramDetail.ts` 發送 `GET /api-proxy/v1/programs/:id` → 代理重寫至 `/api/v1/programs/:id` → 成功渲染 `users/programs/:id`。
+ - 更新 `types/users/programDetail.ts` 對齊 u user 5 回應：新增 `id`、`serial_num`、`views_count`、`favorites_count`、`score`、`total_views`、`weekly_views`、`daily_views`；移除 `is_ongoing`；其餘欄位維持一致。
+ - 保持清單 store 僅保存完整 items（含 `Id`），不另維護獨立 id 清單；詳情 store 維護 `currentProgramId` 與快取，實作仍通過 Lint 檢查。
+ - 驗證 Proxy rewrite 日誌（`/api-proxy/v1/programs/:id → /api/v1/programs/:id`）與 Postman 結果一致；使用者登入狀態下詳情請求攜帶 Authorization 標頭正常。

--- a/types/users/programDetail.ts
+++ b/types/users/programDetail.ts
@@ -28,6 +28,10 @@ export interface ProgramStep {
 }
 
 export interface ProgramDetail {
+  // 主鍵與序號
+  id: number;
+  serial_num: string;
+
   // 公司相關資訊
   company_name: string;
   company_logo: string;
@@ -66,10 +70,15 @@ export interface ProgramDetail {
   status_id: number;
   status_title: string | null;
   
-  // 申請相關
+  // 申請與統計
   applied_count: number;
   days_left: number;
-  is_ongoing: boolean | null;
+  views_count: number;
+  favorites_count: number;
+  score: number;
+  total_views: number;
+  weekly_views: number;
+  daily_views: number;
   
   // 關聯物件
   Industry: IndustryInfo;


### PR DESCRIPTION
決策
- 移除 users/index.vue 開發用 fallback programId 與 dev 分支，改以實際回傳 Id 為準。
- 收斂 resolveProgramId 為 Id ?? id，避免混用舊欄位（ProgramId、ApplicationId 等）。
- 按鈕「查看詳情」流程維持：handleViewDetail → useUserProgramDetailStore.fetchDetail(programId) → 導向 users/programs/:id。
- 更新 types/users/programDetail.ts 以對齊 u-user-5 response：新增 id、serial_num、views_count、favorites_count、score、total_views、weekly_views、daily_views；移除 is_ongoing。
- 維持清單 store 僅保存完整 items（含 Id），詳情 store 維護 currentProgramId 與快取；不另建 id 清單。

理由
- 後端已正確回傳計畫 Id，移除 fallback 可降低維運成本與避免資料不一致。
- 型別與實際回應同步，減少 runtime 風險並強化編譯期保護。
- 清單/詳情分層符合常見前端架構慣例，便於長期擴充與 MGMT。

其他
- 驗證 dev 代理：/api-proxy/v1/programs/:id → /api/v1/programs/:id，與 Postman 結果一致。
- 通過 linter 檢查；無破壞性改動 UI 與現有商業邏輯。