### PR TITLE
feat(user-apply): 串接申請體驗流程與錯誤處理，優化 UX

### DIFF
--- a/composables/api/users/useUserApplications.ts
+++ b/composables/api/users/useUserApplications.ts
@@ -1,0 +1,24 @@
+import { useUserApiFetch } from '~/composables/api/users/useUserApiFetch';
+import type { SubmitApplicationPayload, SubmitApplicationResponse, SubmitApplicationAlreadyAppliedError } from '~/types/users/application';
+
+export const useUserApplications = () => {
+	const submitApplication = async (programId: number | string, payload: SubmitApplicationPayload) => {
+		const url = `/api-proxy/v1/programs/${programId}/applications`;
+		try {
+			const response = await useUserApiFetch<SubmitApplicationResponse>(url, {
+				method: 'POST',
+				body: payload,
+			});
+			return { data: response, status: 201 as 200 | 201 };
+		} catch (err: any) {
+			const status = err?.status as number | undefined;
+			if (status === 400) {
+				const data = err?.data as SubmitApplicationAlreadyAppliedError | undefined;
+				return Promise.reject({ status: 400, data });
+			}
+			return Promise.reject(err);
+		}
+	};
+
+	return { submitApplication };
+};

--- a/pages/users/programs/[programId].vue
+++ b/pages/users/programs/[programId].vue
@@ -335,6 +335,6 @@ const onApplySubmitted = async () => {
     :close-on-click-modal="false"
     :destroy-on-close="true"
   >
-    <UsersApplyExperience @submitted="onApplySubmitted" />
+    <UsersApplyExperience :program-id="programId" @submitted="onApplySubmitted" @close="showApply = false" />
   </el-dialog>
 </template>

--- a/project-steps.md
+++ b/project-steps.md
@@ -24,3 +24,8 @@
  - 更新 `types/users/programDetail.ts` 對齊 u user 5 回應：新增 `id`、`serial_num`、`views_count`、`favorites_count`、`score`、`total_views`、`weekly_views`、`daily_views`；移除 `is_ongoing`；其餘欄位維持一致。
  - 保持清單 store 僅保存完整 items（含 `Id`），不另維護獨立 id 清單；詳情 store 維護 `currentProgramId` 與快取，實作仍通過 Lint 檢查。
  - 驗證 Proxy rewrite 日誌（`/api-proxy/v1/programs/:id → /api/v1/programs/:id`）與 Postman 結果一致；使用者登入狀態下詳情請求攜帶 Authorization 標頭正常。
+ - 新增 users 申請型別至 `types/users/application.ts`，規範 payload 與回應。
+ - 建立 `composables/api/users/useUserApplications.ts`：串接 `POST /api-proxy/v1/programs/{program_id}/applications`，統一處理 201/200 成功與 400 已申請錯誤。
+ - 更新 `components/users/ApplyExperience.vue`：接收 `programId`、整合申請 API、成功顯示提示並 emit `submitted`；400 顯示「已經申請過」並 emit `close` 關閉對話框；email 採用 `v-model.trim` 避免空白導致驗證誤報；`resume_id` 以暫置選單 1/2 供測試。
+ - 更新 `pages/users/programs/[programId].vue`：傳入 `:program-id`，監聽 `submitted/close`；成功導回 `user-landing`，400 僅關閉對話框停留原頁。
+ - 全面通過 Lint 檢查並驗證代理重寫與授權標頭；優化錯誤處理與 UX。

--- a/types/users/application.ts
+++ b/types/users/application.ts
@@ -1,0 +1,20 @@
+export interface SubmitApplicationPayload {
+	participant_id: number;
+	participants_count: number;
+	resume_type: 'existing resume' | 'new resume';
+	resume_id: number;
+	motivation_content: string;
+	agree_terms: boolean;
+}
+
+export interface SubmitApplicationSuccess {
+	success: boolean;
+	application_number: string;
+	message: string;
+}
+
+export interface SubmitApplicationAlreadyAppliedError {
+	Message: string;
+}
+
+export type SubmitApplicationResponse = SubmitApplicationSuccess;


### PR DESCRIPTION
- 新增 types/users/application.ts：定義 SubmitApplicationPayload/Response 與 400 錯誤型別
- 建立 composables/api/users/useUserApplications.ts：封裝 POST /v1/programs/{id}/applications，注入 Token，統一處理 201/200/400
- 更新 components/users/ApplyExperience.vue：接收 programId、送出申請、成功提示並 emit submitted；400 顯示「已申請」並 emit close 關閉對話框；email 採 v-model.trim；履歷以數字 resume_id 暫置
- 更新 pages/users/programs/[programId].vue：傳遞 :program-id，監聽 submitted/close；成功導回 user-landing，400 僅關閉對話框停留原頁
- 通過 Lint，驗證代理重寫與授權標頭；改善錯誤訊息與互動體驗

理由：
- 封裝 API 以符合單一職責、利於擴展（後續履歷清單/上傳、更多錯誤碼）
- 明確處理狀態碼，避免錯誤導頁或 UX 混亂
- 去除 email 空白造成的驗證誤報，提升表單成功率