### PR TITLE
fix(user-auth): 移除 register 錯誤的 error 解構，改用 try/catch

### DIFF
--- a/project-steps.md
+++ b/project-steps.md
@@ -33,3 +33,9 @@
  - 新增 `useUserApiFetchRaw`：取得 raw 回應含 HTTP 狀態碼，沿用 Users JWT 注入策略。
  - 更新 `composables/api/users/useUserApplications.ts`：改用 raw 版，統一成功條件（`200/201`）與 `400` 已申請錯誤拋出；其他狀態交由上層處理。
  - 通過 Lint 檢查；不改動 UI，保留 `ApplyExperience.vue` 既有成功訊息。
+
+## 2025-09-01
+- 修復 users 註冊流程型別錯誤：移除 `{ error }` 解構，對齊 `$fetch` 直接回傳資料物件。
+- 更新 `stores/user/useAuthStore.ts` 的 `register`：改用 `try/catch` 捕捉錯誤並統一訊息格式，減少上層判斷負擔。
+- 驗證 Lint 檢查為綠燈；不改動 API 介面與 UI 呈現，降低影響範圍。
+- 提出替代方案：可改用 `useApiFetch/useFetch` 回傳 `{ data, error }`，惟影響面較大，暫採最小變更策略以維持穩定性。

--- a/stores/user/useAuthStore.ts
+++ b/stores/user/useAuthStore.ts
@@ -51,10 +51,11 @@ export const useUserAuthStore = defineStore('userAuth', () => {
 
   async function register(registerData: UserRegisterData) {
     const userRegister = useUserRegister();
-    const { error } = await userRegister.register(registerData);
-
-    if (error.value) {
-      throw error.value;
+    try {
+      await userRegister.register(registerData);
+    } catch (err: any) {
+      const message = err?.data?.message || err?.message || '註冊失敗：伺服器錯誤';
+      throw new Error(message);
     }
   }
   


### PR DESCRIPTION
## 2025-09-01
- 修復 users 註冊流程型別錯誤：移除 `{ error }` 解構，對齊 `$fetch` 直接回傳資料物件。
- 更新 `stores/user/useAuthStore.ts` 的 `register`：改用 `try/catch` 捕捉錯誤並統一訊息格式，減少上層判斷負擔。
- 驗證 Lint 檢查為綠燈；不改動 API 介面與 UI 呈現，降低影響範圍。
- 提出替代方案：可改用 `useApiFetch/useFetch` 回傳 `{ data, error }`，惟影響面較大，暫採最小變更策略以維持穩定性。