### PR TITLE
feat(users): implement evaluation submission with enhanced error hand…

### DIFF
--- a/composables/api/users/useUserEvaluation.ts
+++ b/composables/api/users/useUserEvaluation.ts
@@ -1,12 +1,15 @@
 import type { SubmitEvaluationPayload, SubmitEvaluationResponse } from '~/types/users/comment';
+import { useUserApiFetch } from './useUserApiFetch';
 
 export const useUserEvaluation = () => {
   const submitEvaluation = async (serialNum: string | number, payload: SubmitEvaluationPayload) => {
-    const url = `/api-proxy/v1/comments/${serialNum}/evaluation`;
+    // 使用硬編碼的 programId (45) 和 userId (2) 作為測試值
+    const url = `/api-proxy/v1/users/2/programs/45/evaluations`;
 
     try {
-      const data = await $fetch<SubmitEvaluationResponse>(url, {
-        method: 'POST',
+      // 使用 useUserApiFetch 確保 JWT token 被注入
+      const data = await useUserApiFetch<SubmitEvaluationResponse>(url, {
+        method: 'PUT',
         body: payload,
       });
       

--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -170,13 +170,27 @@ async function submitEvaluationForItem(item: ReviewItem) {
     
     // 錯誤處理
     let errorMessage = '提交失敗，請稍後重試';
-    if (error.message) {
+    
+    // 處理後端錯誤回應
+    if (error.data?.Message) {
+      errorMessage = error.data.Message;
+      
+      // 特殊處理「體驗尚未結束」錯誤
+      if (errorMessage === '體驗尚未結束') {
+        ElMessage.warning('體驗尚未結束');
+        // 退出編輯模式，收合多行輸入框
+        delete editingEvaluation.value[item.serial_num];
+        return;
+      }
+    } else if (error.message) {
       if (error.message.includes('網路')) {
         errorMessage = '網路連線異常，請檢查網路後重試';
       } else if (error.message.includes('認證') || error.message.includes('登入')) {
         errorMessage = '登入已過期，請重新登入';
       } else if (error.message.includes('維護')) {
         errorMessage = '服務暫時維護中，請稍後再試';
+      } else {
+        errorMessage = error.message;
       }
     }
     

--- a/project-steps.md
+++ b/project-steps.md
@@ -50,3 +50,11 @@
 - 新增調試資訊：在 `useUserApiFetch.ts` 和 `useUserComments.ts` 中添加 console 日誌，便於追蹤 token 注入過程和認證狀態。
 - 驗證 API 整合成功：評價列表頁面現在能正確顯示 "共 5 則評價"，並成功渲染包含公司名稱、計畫名稱、狀態標籤等完整資訊的評價項目。
 - 通過 Lint 檢查：所有修改都符合專案的程式碼風格規範，未引入新的 linter 錯誤。
+
+## 2025-09-02 (續)
+- 實作 users 修改評價功能：建立 `PUT /api/v1/users/{userId}/programs/{programId}/evaluations` API 整合，使用硬編碼的 `userId=2` 和 `programId=45` 作為測試值。
+- 更新評價相關類型定義：在 `types/users/comment.ts` 中新增 `SubmitEvaluationSuccessResponse` 和 `SubmitEvaluationErrorResponse` 介面，支援後端定義的成功和錯誤回應格式。
+- 修正評價提交 API 邏輯：將 `composables/api/users/useUserEvaluation.ts` 從使用 `$fetch` 改為 `useUserApiFetch`，確保 JWT token 被正確注入，並更新 HTTP 方法為 `PUT`。
+- 強化錯誤處理機制：在 `pages/users/comments/index.vue` 中新增對「體驗尚未結束」錯誤的特殊處理，使用 `ElMessage.warning` 顯示警告訊息並自動退出編輯模式。
+- 優化用戶體驗：當收到「體驗尚未結束」錯誤時，系統會自動清除編輯狀態並收合評價輸入框，提供更流暢的互動體驗。
+- 通過 Lint 檢查：所有修改都符合專案的程式碼風格規範，未引入新的 linter 錯誤。

--- a/types/users/comment.ts
+++ b/types/users/comment.ts
@@ -31,7 +31,22 @@ export interface SubmitEvaluationPayload {
   comment: string;
 }
 
-export interface SubmitEvaluationResponse {
-  success: boolean;
-  message?: string;
+// 修改評價成功回應
+export interface SubmitEvaluationSuccessResponse {
+  ProgramName: string;
+  ProgramStartDate: string;
+  ProgramEndDate: string;
+  CompanyName: string;
+  Score: number;
+  Comment: string;
+  SerialNum: string;
+  AiStatus: number;
 }
+
+// 修改評價錯誤回應
+export interface SubmitEvaluationErrorResponse {
+  Message: string;
+}
+
+// 修改評價回應（成功或錯誤）
+export type SubmitEvaluationResponse = SubmitEvaluationSuccessResponse | SubmitEvaluationErrorResponse;


### PR DESCRIPTION
## 2025-09-02 (續)
- 實作 users 修改評價功能：建立 `PUT /api/v1/users/{userId}/programs/{programId}/evaluations` API 整合，使用硬編碼的 `userId=2` 和 `programId=45` 作為測試值。
- 更新評價相關類型定義：在 `types/users/comment.ts` 中新增 `SubmitEvaluationSuccessResponse` 和 `SubmitEvaluationErrorResponse` 介面，支援後端定義的成功和錯誤回應格式。
- 修正評價提交 API 邏輯：將 `composables/api/users/useUserEvaluation.ts` 從使用 `$fetch` 改為 `useUserApiFetch`，確保 JWT token 被正確注入，並更新 HTTP 方法為 `PUT`。
- 強化錯誤處理機制：在 `pages/users/comments/index.vue` 中新增對「體驗尚未結束」錯誤的特殊處理，使用 `ElMessage.warning` 顯示警告訊息並自動退出編輯模式。
- 優化用戶體驗：當收到「體驗尚未結束」錯誤時，系統會自動清除編輯狀態並收合評價輸入框，提供更流暢的互動體驗。