### PR TITLE
fix(api): correct API field mapping for program detail response

### DIFF
--- a/composables/api/company/useApplicant.ts
+++ b/composables/api/company/useApplicant.ts
@@ -1,10 +1,24 @@
 import type { ApplicantDetail } from '~/types/company/applicant';
 import { useCompanyApiFetch } from '~/composables/api/company/useCompanyApiFetch';
 
-export const useApplicant = (programId: string | number, applicantId: string | number) => {
-  const url = `/api/v1/programs/${programId}/applications/${applicantId}`;
+export const useApplicant = (
+  companyId: MaybeRefOrGetter<number | null>,
+  programId: MaybeRefOrGetter<string | number>,
+  applicantId: MaybeRefOrGetter<string | number>
+) => {
+  const url = computed(() => {
+    const resolvedCompanyId = toValue(companyId);
+    const resolvedProgramId = toValue(programId);
+    const resolvedApplicantId = toValue(applicantId);
+    
+    // 當 companyId 為空時，返回 null，不發送請求
+    if (!resolvedCompanyId || !resolvedProgramId || !resolvedApplicantId) return null;
+    
+    return `/api/v1/company/${resolvedCompanyId}/programs/${resolvedProgramId}/applications/${resolvedApplicantId}`;
+  });
 
   return useCompanyApiFetch<ApplicantDetail>(url, {
-    key: `applicant-${applicantId}`,
+    key: `applicant-${toValue(applicantId)}`,
+    immediate: !!toValue(companyId) && !!toValue(programId) && !!toValue(applicantId),
   });
 };

--- a/composables/api/company/useApplicants.ts
+++ b/composables/api/company/useApplicants.ts
@@ -12,11 +12,11 @@ export const useApplicants = (companyId: MaybeRefOrGetter<number | null>, progra
   const url = computed(() => {
     const resolvedCompanyId = toValue(companyId);
     const resolvedProgramId = toValue(programId);
-    if (!resolvedCompanyId) return '';
+    if (!resolvedCompanyId || !resolvedProgramId) return null;
     return `/api/v1/company/${resolvedCompanyId}/programs/${resolvedProgramId}/applications`;
   });
 
   return useCompanyApiFetch<ApplicantsListResponse>(url, {
-    immediate: !!toValue(companyId),
+    immediate: !!toValue(companyId) && !!toValue(programId),
   });
 };

--- a/composables/api/company/useProgramDetail.ts
+++ b/composables/api/company/useProgramDetail.ts
@@ -1,14 +1,21 @@
 import { useCompanyApiFetch } from '~/composables/api/company/useCompanyApiFetch';
 import type { ProgramDetailResponse } from '~/types/company/program';
 
-export const useProgramDetail = (programId: MaybeRefOrGetter<string | number>) => {
+export const useProgramDetail = (
+  companyId: MaybeRefOrGetter<number | null>,
+  programId: MaybeRefOrGetter<string | number>
+) => {
   const url = computed(() => {
+    const resolvedCompanyId = toValue(companyId);
     const resolvedProgramId = toValue(programId);
-    if (!resolvedProgramId) return '';
-    return `/api/v1/programs/${resolvedProgramId}`;
+    
+    // 當 companyId 或 programId 為空時，返回 null，不發送請求
+    if (!resolvedCompanyId || !resolvedProgramId) return null;
+    
+    return `/api/v1/company/${resolvedCompanyId}/programs/${resolvedProgramId}`;
   });
 
   return useCompanyApiFetch<ProgramDetailResponse>(url, {
-    immediate: !!toValue(programId),
+    immediate: !!toValue(companyId) && !!toValue(programId),
   });
 };

--- a/composables/api/company/useSubmitReview.ts
+++ b/composables/api/company/useSubmitReview.ts
@@ -19,15 +19,22 @@ export const useSubmitReview = () => {
   const data = ref<SubmitReviewResponse | null>(null);
 
   const submit = async (
+    companyId: number | null,
     programId: string | number,
     participantId: string | number,
     payload: SubmitReviewPayload,
   ) => {
+    // 當 companyId 為空時，設置錯誤並返回
+    if (!companyId) {
+      error.value = { message: '企業資訊載入中，請稍後再試' } as FetchError;
+      return;
+    }
+
     loading.value = true;
     error.value = null;
     data.value = null;
 
-    const url = `/api/v1/programs/${programId}/applications/${participantId}/review`;
+    const url = `/api/v1/company/${companyId}/programs/${programId}/applications/${participantId}/review`;
 
     const { data: result, error: fetchError } = await useCompanyApiFetch<SubmitReviewResponse>(url, {
       method: 'PUT',

--- a/pages/admin/programs/[programId].vue
+++ b/pages/admin/programs/[programId].vue
@@ -76,34 +76,22 @@
     <section class="rounded border border-gray-200 bg-white p-4 shadow-sm md:p-6">
       <div class="space-y-8">
         <!-- Intro -->
-        <div>
+        <div v-if="parsedIntro?.experienceIntro || parsedIntro?.fallback">
           <h2 class="mb-3 text-xl font-semibold text-gray-900">體驗介紹</h2>
-          <p class="leading-7 text-gray-800">{{ program.intro }}</p>
+          <p class="leading-7 text-gray-800">{{ parsedIntro?.experienceIntro || parsedIntro?.fallback }}</p>
         </div>
 
         <!-- Teacher -->
-        <div>
+        <div v-if="parsedIntro?.teacherIntro">
           <h2 class="mb-3 text-xl font-semibold text-gray-900">師資介紹</h2>
-          <h3 class="text-lg font-semibold text-gray-900">{{ program.teacher.name }}</h3>
-          <p class="mt-2 leading-7 text-gray-800">{{ program.teacher.bio }}</p>
-        </div>
-
-        <!-- Resume List -->
-        <div>
-          <h2 class="mb-3 text-xl font-semibold text-gray-900">經歷</h2>
-          <ul class="list-disc space-y-2 pl-6 text-gray-800">
-            <li v-for="(exp, idx) in program.experiences" :key="idx">
-              <div class="font-semibold">{{ exp.title }}</div>
-              <div class="text-gray-700">{{ exp.description }}</div>
-            </li>
-          </ul>
+          <p class="leading-7 text-gray-800">{{ parsedIntro.teacherIntro }}</p>
         </div>
 
         <!-- Requirements -->
-        <div>
+        <div v-if="parsedIntro?.requirements && parsedIntro.requirements.length > 0">
           <h2 class="mb-3 text-xl font-semibold text-gray-900">參加限制</h2>
           <ol class="list-decimal space-y-1 pl-6 text-gray-800">
-            <li v-for="(req, idx) in program.requirements" :key="idx">{{ req }}</li>
+            <li v-for="(req, idx) in parsedIntro.requirements" :key="idx">{{ req }}</li>
           </ol>
         </div>
       </div>
@@ -112,19 +100,11 @@
     <!-- Pre-Notes / Checklist / Flow / Location -->
     <section class="rounded border border-gray-200 bg-white p-4 shadow-sm md:p-6">
       <div class="space-y-8">
-        <!-- Pre-Notes -->
-        <div>
-          <h2 class="mb-3 text-xl font-semibold text-gray-900">行前須知、注意事項</h2>
+        <!-- Pre-Notes / Preparation -->
+        <div v-if="parsedIntro?.preparation && parsedIntro.preparation.length > 0">
+          <h2 class="mb-3 text-xl font-semibold text-gray-900">行前須知與準備清單</h2>
           <ol class="list-decimal space-y-1 pl-6 text-gray-800">
-            <li v-for="(n, i) in program.preNotes" :key="i">{{ n }}</li>
-          </ol>
-        </div>
-
-        <!-- Checklist -->
-        <div>
-          <h2 class="mb-3 text-xl font-semibold text-gray-900">準備清單</h2>
-          <ol class="list-decimal space-y-1 pl-6 text-gray-800">
-            <li v-for="(item, i) in program.checklist" :key="i">{{ item }}</li>
+            <li v-for="(item, i) in parsedIntro.preparation" :key="i">{{ item }}</li>
           </ol>
         </div>
 
@@ -227,7 +207,8 @@
 definePageMeta({ name: 'admin-single-program-info', layout: 'admin' as any })
 
 import LocationPinIcon from '~/components/shared/LocationPinIcon.vue'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { parseIntroContent } from '~/utils/introParser'
 
 type ReviewStatus = 'systemApproved' | 'systemRejected' | 'manualConfirmed' | 'manualRejected'
 
@@ -384,6 +365,12 @@ const program: ProgramDetails = {
 
 const reviewResult = ref<'approved' | 'rejected'>('approved')
 const reviewNote = ref('')
+
+// 解析 intro 內容
+const parsedIntro = computed(() => {
+  if (!program.intro) return null;
+  return parseIntroContent(program.intro);
+});
 
 const onSubmitReview = () => {
   // 僅示意 UI 提交行為；之後可串接 API

--- a/pages/company/programs/[programId]/applicants/[applicantId].vue
+++ b/pages/company/programs/[programId]/applicants/[applicantId].vue
@@ -31,9 +31,12 @@ const {
 
 const formRef = ref<FormInstance>();
 
+const authStore = useCompanyAuthStore();
+
 const { data: applicantData, pending } = useApplicant(
-  String(route.params.programId),
-  String(route.params.applicantId),
+  computed(() => authStore.companyId),
+  computed(() => String(route.params.programId)),
+  computed(() => String(route.params.applicantId)),
 );
 
 const applicant = computed<Partial<ApplicantDetail>>(() => applicantData.value || {});
@@ -67,7 +70,7 @@ const submitReview = async (formEl: FormInstance | undefined) => {
       const programId = String(route.params.programId);
       const applicantId = String(route.params.applicantId);
 
-      await submitReviewApi(programId, applicantId, {
+      await submitReviewApi(authStore.companyId, programId, applicantId, {
         status_id: decisionForm.value.status === 'pending' ? 2 : 3, // 2=核准申請, 3=婉拒申請
         comment: decisionForm.value.feedback,
       });

--- a/pages/company/programs/index.vue
+++ b/pages/company/programs/index.vue
@@ -3,12 +3,34 @@
     <h1>企業計畫列表</h1>
     <div v-if="programStore.programs.length > 0">
       <div v-for="program in programStore.programs" :key="program.Id" class="program-card">
-        <h2>{{ program.Name }}</h2>
-        <p>{{ program.Intro }}</p>
-        <p>產業: {{ program.Industry.Title }}</p>
-        <p>職位: {{ program.JobTitle.Title }}</p>
-        <p>發佈時間: {{ program.PublishStartDate }} - {{ program.PublishEndDate }}</p>
-        <p>計畫時間: {{ program.ProgramStartDate }} - {{ program.ProgramEndDate }}</p>
+        <!-- 封面圖片 -->
+        <div v-if="program.CoverImage" class="program-cover">
+          <NuxtImg 
+            :src="program.CoverImage" 
+            :alt="program.Name"
+            class="cover-image"
+            @error="handleImageError"
+          />
+        </div>
+        <div v-else class="program-cover no-image">
+          <div class="no-image-placeholder">
+            <font-awesome-icon :icon="['fas', 'image']" class="placeholder-icon" />
+            <span>無封面圖片</span>
+          </div>
+        </div>
+        
+        <!-- 計畫資訊 -->
+        <div class="program-info">
+          <h2>{{ program.Name }}</h2>
+          <p class="intro">{{ program.Intro }}</p>
+          <div class="program-details">
+            <p><strong>產業:</strong> {{ program.Industry.Title }}</p>
+            <p><strong>職位:</strong> {{ program.JobTitle.Title }}</p>
+            <p><strong>發佈時間:</strong> {{ program.PublishStartDate }} - {{ program.PublishEndDate }}</p>
+            <p><strong>計畫時間:</strong> {{ program.ProgramStartDate }} - {{ program.ProgramEndDate }}</p>
+            <p><strong>申請人數:</strong> {{ program.AppliedCount || 0 }} 人</p>
+          </div>
+        </div>
       </div>
       <el-pagination
         :current-page="programStore.page"
@@ -38,6 +60,17 @@ onMounted(() => {
 const handlePageChange = (newPage: number) => {
   programStore.setPage(newPage);
 };
+
+// 處理圖片載入錯誤
+const handleImageError = (payload: string | Event) => {
+  if (typeof payload === 'string') return;
+  
+  const e = payload as Event;
+  const img = e.target as HTMLImageElement;
+  if (img) {
+    img.style.display = 'none';
+  }
+};
 </script>
 
 <style scoped>
@@ -46,5 +79,93 @@ const handlePageChange = (newPage: number) => {
   padding: 16px;
   margin-bottom: 16px;
   border-radius: 8px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.program-cover {
+  width: 200px;
+  height: 150px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #f5f5f5;
+}
+
+.cover-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.no-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f0f0f0;
+  border: 2px dashed #ccc;
+}
+
+.no-image-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: #666;
+}
+
+.placeholder-icon {
+  font-size: 24px;
+  color: #999;
+}
+
+.program-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.program-info h2 {
+  margin: 0 0 8px 0;
+  color: #333;
+  font-size: 18px;
+}
+
+.intro {
+  margin: 0 0 12px 0;
+  color: #666;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.program-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.program-details p {
+  margin: 0;
+  font-size: 14px;
+  color: #555;
+}
+
+.program-details strong {
+  color: #333;
+}
+
+/* 響應式設計 */
+@media (max-width: 768px) {
+  .program-card {
+    flex-direction: column;
+  }
+  
+  .program-cover {
+    width: 100%;
+    height: 200px;
+  }
 }
 </style>

--- a/pages/users/programs/[programId].vue
+++ b/pages/users/programs/[programId].vue
@@ -8,6 +8,7 @@ definePageMeta({
 import { ref, onMounted, computed } from 'vue';
 import { userRoutes } from '~/utils/userRoutes';
 import { useUserProgramDetailStore } from '~/stores/user/useUserProgramDetailStore';
+import { parseIntroContent } from '~/utils/introParser';
 
 const router = useRouter();
 const isFavorited = ref(false);
@@ -33,6 +34,12 @@ const programDetail = computed(() => programDetailStore.programDetail);
 const isLoading = computed(() => programDetailStore.loading);
 const hasError = computed(() => programDetailStore.hasError);
 const errorMessage = computed(() => programDetailStore.error);
+
+// 解析 intro 內容
+const parsedIntro = computed(() => {
+  if (!programDetail.value?.intro) return null;
+  return parseIntroContent(programDetail.value.intro);
+});
 
 // 頁面載入時取得計畫詳情
 onMounted(async () => {
@@ -211,63 +218,38 @@ const onApplySubmitted = async () => {
           <!-- 內文段落 -->
           <div class="space-y-8 text-gray-800">
             <!-- 體驗介紹 -->
-            <section>
+            <section v-if="parsedIntro?.experienceIntro || parsedIntro?.fallback">
               <h4 class="mb-3 text-lg font-bold">體驗介紹</h4>
               <p class="leading-7">
-                {{ programDetail.intro }}
+                {{ parsedIntro?.experienceIntro || parsedIntro?.fallback }}
               </p>
             </section>
 
             <!-- 師資介紹 -->
-            <section>
+            <section v-if="parsedIntro?.teacherIntro">
               <h4 class="mb-3 text-lg font-bold">師資介紹</h4>
-              <p class="mb-2 font-semibold">林德榮</p>
               <p class="leading-7">
-                產業軟體與平台架構經驗逾 10 年，歷任後端開發、系統架構與平台穩定度維運，亦擔任內部講師推動
-                DevOps 與工程文化。擅長 B2B／平台類產品的模組化與可維運性設計。
+                {{ parsedIntro.teacherIntro }}
               </p>
             </section>
 
-            <!-- 經歷 -->
-            <section>
-              <h4 class="mb-3 text-lg font-bold">經歷</h4>
-              <ul class="list-disc space-y-2 pl-6">
-                <li>國際級電商系統架構師：協助平台完成數位轉型，實現高可用與高擴展。</li>
-                <li>知名新創公司資深軟體工程師：參與 API 設計、導入 CI/CD 流程、優化交付週期。</li>
-                <li>跨部門平台技術顧問：建立高流量環境下的穩定性與監控機制。</li>
-              </ul>
-            </section>
-
             <!-- 參加限制 -->
-            <section>
+            <section v-if="parsedIntro?.requirements && parsedIntro.requirements.length > 0">
               <h4 class="mb-3 text-lg font-bold">參加限制</h4>
               <ol class="list-decimal space-y-1 pl-6">
-                <li>了解 JS 語法、陣列物件、DOM、事件、AJAX 等基礎。</li>
-                <li>建議具備可瀏覽的程式作品（JS Code、Codepen、GitHub Pages）。</li>
-                <li>18 歲以上。</li>
+                <li v-for="requirement in parsedIntro.requirements" :key="requirement">
+                  {{ requirement }}
+                </li>
               </ol>
             </section>
 
-            <!-- 行前須知、注意事項 -->
-            <section>
-              <h4 class="mb-3 text-lg font-bold">行前須知、注意事項</h4>
+            <!-- 行前須知與準備清單 -->
+            <section v-if="parsedIntro?.preparation && parsedIntro.preparation.length > 0">
+              <h4 class="mb-3 text-lg font-bold">行前須知與準備清單</h4>
               <ol class="list-decimal space-y-1 pl-6">
-                <li>準時參與並全程配合課程安排，珍惜與講師互動。</li>
-                <li>體驗課為入門性質，不保證完成後即能就業。</li>
-                <li>活動過程可能拍攝紀錄，僅作為教學回放用途。</li>
-                <li>如有不可抗力因素，請提前於平台取消。</li>
-              </ol>
-            </section>
-
-            <!-- 準備清單 -->
-            <section>
-              <h4 class="mb-3 text-lg font-bold">準備清單</h4>
-              <ol class="list-decimal space-y-1 pl-6">
-                <li>筆記型電腦</li>
-                <li>水壺</li>
-                <li>證件（身份證、健保卡）</li>
-                <li>手抄筆記工具</li>
-                <li>長效外接電源</li>
+                <li v-for="item in parsedIntro.preparation" :key="item">
+                  {{ item }}
+                </li>
               </ol>
             </section>
           </div>

--- a/stores/company/useProgramDetailStore.ts
+++ b/stores/company/useProgramDetailStore.ts
@@ -15,13 +15,17 @@ export const useCompanyProgramDetailStore = defineStore('company-program-detail'
     if (!programDetail.value) return null;
     
     return {
-      totalViews: programDetail.value.total_views,
-      weeklyViews: programDetail.value.weekly_views,
-      dailyViews: programDetail.value.daily_views,
-      appliedCount: programDetail.value.applied_count,
-      favoritesCount: programDetail.value.favorites_count,
-      score: programDetail.value.score,
-      daysLeft: programDetail.value.days_left,
+      totalViews: programDetail.value.Views?.TotalViews ?? 0,
+      weeklyViews: programDetail.value.Views?.WeeklyViews ?? 0,
+      dailyViews: programDetail.value.Views?.DailyViews ?? 0,
+      appliedCount: 0, // 這個欄位在新 API 中不存在，使用 Statistics 替代
+      favoritesCount: 0, // 這個欄位在新 API 中不存在
+      score: 0, // 這個欄位在新 API 中不存在
+      daysLeft: 0, // 這個欄位在新 API 中不存在
+      // 從新的 Statistics 物件中取得申請統計
+      totalApplicants: programDetail.value.Statistics?.TotalApplicants ?? 0,
+      reviewedCount: programDetail.value.Statistics?.ReviewedCount ?? 0,
+      pendingCount: programDetail.value.Statistics?.PendingCount ?? 0,
     };
   });
 
@@ -29,28 +33,28 @@ export const useCompanyProgramDetailStore = defineStore('company-program-detail'
     if (!programDetail.value) return null;
     
     return {
-      id: programDetail.value.id,
-      name: programDetail.value.name,
-      intro: programDetail.value.intro,
-      companyName: programDetail.value.company_name,
-      companyLogo: programDetail.value.company_logo,
-      companyCover: programDetail.value.company_cover,
-      serialNum: programDetail.value.serial_num,
-      address: programDetail.value.address,
-      addressMap: programDetail.value.address_map,
-      contactName: programDetail.value.contact_name,
-      contactPhone: programDetail.value.contact_phone,
-      contactEmail: programDetail.value.contact_email,
-      minPeople: programDetail.value.min_people,
-      maxPeople: programDetail.value.max_people,
-      publishStartDate: programDetail.value.publish_start_date,
-      publishDurationDays: programDetail.value.publish_duration_days,
-      publishEndDate: programDetail.value.publish_end_date,
-      programStartDate: programDetail.value.program_start_date,
-      programEndDate: programDetail.value.program_end_date,
-      programDurationDays: programDetail.value.program_duration_days,
-      statusId: programDetail.value.status_id,
-      statusTitle: programDetail.value.status_title,
+      id: programDetail.value.Id,
+      name: programDetail.value.Name,
+      intro: programDetail.value.Intro,
+      companyName: '', // 這個欄位在新 API 中不存在
+      companyLogo: '', // 這個欄位在新 API 中不存在
+      companyCover: '', // 這個欄位在新 API 中不存在
+      serialNum: '', // 這個欄位在新 API 中不存在
+      address: programDetail.value.Address,
+      addressMap: '', // 這個欄位在新 API 中不存在
+      contactName: programDetail.value.ContactName,
+      contactPhone: programDetail.value.ContactPhone,
+      contactEmail: '', // 這個欄位在新 API 中不存在
+      minPeople: programDetail.value.MinPeople,
+      maxPeople: programDetail.value.MaxPeople,
+      publishStartDate: programDetail.value.PublishStartDate,
+      publishDurationDays: programDetail.value.PublishDurationDays,
+      publishEndDate: programDetail.value.PublishEndDate,
+      programStartDate: programDetail.value.ProgramStartDate,
+      programEndDate: programDetail.value.ProgramEndDate,
+      programDurationDays: programDetail.value.ProgramDurationDays,
+      statusId: programDetail.value.Status.Id,
+      statusTitle: programDetail.value.Status.Title,
       industry: programDetail.value.Industry,
       jobTitle: programDetail.value.JobTitle,
       status: programDetail.value.Status,

--- a/types/company/program.ts
+++ b/types/company/program.ts
@@ -12,6 +12,8 @@ export interface ProgramStep {
   Id: number;
   Name: string;
   Description: string;
+  CreatedAt: string;
+  UpdatedAt: string;
 }
 
 export interface ProgramImage {
@@ -71,6 +73,7 @@ export interface Program {
   Status: ProgramStatus;
   applied_count: number;
   AppliedCount: number; // 新版本 API 回應欄位
+  CoverImage: string | null; // 新版本 API 回應欄位 - 封面圖片
   Images: ProgramImage[];
   Steps: ProgramStep[];
   Statistics: ProgramStatistics;
@@ -126,39 +129,16 @@ export interface ProgramDetailStep {
   Description: string;
 }
 
+export interface ProgramDetailStatistics {
+  TotalApplicants: number;
+  ReviewedCount: number;
+  PendingCount: number;
+}
+
 export interface ProgramDetailResponse {
-  id: number;
-  company_name: string;
-  company_logo: string;
-  company_cover: string;
-  serial_num: string;
-  name: string;
-  intro: string;
-  industry_id: number;
-  job_title_id: number;
-  address: string;
-  address_map: string | null;
-  contact_name: string;
-  contact_phone: string;
-  contact_email: string;
-  min_people: number;
-  max_people: number;
-  publish_start_date: string;
-  publish_duration_days: number;
-  publish_end_date: string;
-  program_start_date: string;
-  program_end_date: string;
-  program_duration_days: number;
-  status_id: number;
-  status_title: string;
-  views_count: number;
-  favorites_count: number;
-  applied_count: number;
-  score: number;
-  days_left: number;
-  total_views: number;
-  weekly_views: number;
-  daily_views: number;
+  Id: number;
+  Name: string;
+  Intro: string;
   Industry: {
     Id: number;
     Title: string;
@@ -171,6 +151,23 @@ export interface ProgramDetailResponse {
     Id: number;
     Title: string;
   };
-  Images: string[];
+  Address: string;
+  ContactName: string;
+  ContactPhone: string;
+  MinPeople: number;
+  MaxPeople: number;
+  PublishStartDate: string;
+  PublishDurationDays: number;
+  PublishEndDate: string;
+  ProgramStartDate: string;
+  ProgramEndDate: string;
+  ProgramDurationDays: number;
+  Statistics: ProgramDetailStatistics;
   Steps: ProgramDetailStep[];
+  Images: ProgramImage[];
+  Views: {
+    TotalViews: number;
+    WeeklyViews: number;
+    DailyViews: number;
+  };
 }

--- a/utils/introParser.ts
+++ b/utils/introParser.ts
@@ -1,0 +1,110 @@
+/**
+ * Intro 內容解析工具
+ * 用於解析 e comp 7 API 回應中的 intro 欄位內容
+ * 支援新格式（結構化）和舊格式（純文字）的向後相容
+ */
+
+export interface ParsedIntro {
+  experienceIntro?: string;
+  teacherIntro?: string;
+  requirements?: string[];
+  preparation?: string[];
+  fallback?: string; // 原始內容，用於向後相容
+}
+
+/**
+ * 解析 intro 內容
+ * @param intro 原始 intro 字串
+ * @returns 解析後的結構化內容
+ */
+export function parseIntroContent(intro: string): ParsedIntro {
+  if (!intro || typeof intro !== 'string') {
+    return { fallback: intro || '' };
+  }
+
+  // 檢查是否為新格式（包含 \r\n\r\n 或 \n\n 分隔符）
+  if (!intro.includes('\r\n\r\n') && !intro.includes('\n\n')) {
+    return { fallback: intro };
+  }
+
+  try {
+    // 按 \r\n\r\n 或 \n\n 分割主要區塊
+    const separator = intro.includes('\r\n\r\n') ? '\r\n\r\n' : '\n\n';
+    const blocks = intro.split(separator).map(block => block.trim()).filter(block => block.length > 0);
+    
+    const result: ParsedIntro = {};
+
+    for (const block of blocks) {
+      const blockLower = block.toLowerCase();
+      
+      // 體驗介紹
+      if (blockLower.includes('體驗介紹：') || blockLower.includes('體驗介紹')) {
+        result.experienceIntro = extractContentAfterColon(block);
+      }
+      // 師資介紹
+      else if (blockLower.includes('師資介紹：') || blockLower.includes('師資介紹')) {
+        result.teacherIntro = extractContentAfterColon(block);
+      }
+      // 參加限制
+      else if (blockLower.includes('參加限制：') || blockLower.includes('參加限制')) {
+        result.requirements = extractListItems(block);
+      }
+      // 行前須知與準備清單
+      else if (blockLower.includes('行前須知') || blockLower.includes('準備清單')) {
+        result.preparation = extractListItems(block);
+      }
+    }
+
+    // 如果沒有解析到任何結構化內容，回退到原始內容
+    if (!result.experienceIntro && !result.teacherIntro && !result.requirements && !result.preparation) {
+      return { fallback: intro };
+    }
+
+    return result;
+  } catch (error) {
+    // 解析失敗時回退到原始內容
+    console.warn('Intro 解析失敗，使用原始內容:', error);
+    return { fallback: intro };
+  }
+}
+
+/**
+ * 提取冒號後的內容
+ * @param text 包含冒號的文字
+ * @returns 冒號後的內容
+ */
+function extractContentAfterColon(text: string): string {
+  const colonIndex = text.indexOf('：');
+  if (colonIndex === -1) {
+    return text;
+  }
+  return text.substring(colonIndex + 1).trim();
+}
+
+/**
+ * 提取列表項目
+ * @param text 包含列表的文字
+ * @returns 列表項目陣列
+ */
+function extractListItems(text: string): string[] {
+  const content = extractContentAfterColon(text);
+  
+  // 按 \r\n 或 \n 分割，然後過濾空行
+  const lineSeparator = content.includes('\r\n') ? '\r\n' : '\n';
+  const lines = content.split(lineSeparator).map(line => line.trim()).filter(line => line.length > 0);
+  
+  // 處理編號列表（如 "1.項目" 或 "1)項目"）
+  return lines.map(line => {
+    // 移除開頭的編號（如 "1."、"1)"、"1、" 等）
+    return line.replace(/^\d+[\.\)、]\s*/, '').trim();
+  });
+}
+
+/**
+ * 檢查是否為新格式的 intro 內容
+ * @param intro intro 字串
+ * @returns 是否為新格式
+ */
+export function isNewFormatIntro(intro: string): boolean {
+  return Boolean(intro && (intro.includes('\r\n\r\n') || intro.includes('\n\n')));
+}


### PR DESCRIPTION
修正企業計畫詳情 API 回應的欄位對應問題，確保 introParser 能正確解析內容。

主要問題：
- API 回應使用 PascalCase 欄位名稱（如 Intro, Name, Id）
- 型別定義和 Store 使用 camelCase 欄位名稱（如 intro, name, id）
- 導致 program.value.intro 為 undefined，parsedIntro 無法正確解析

解決方案：
- 更新 ProgramDetailResponse 介面以匹配實際 API 回應格式
- 修正 useProgramDetailStore 中的欄位對應關係
- 確保 introParser.ts 能正確取得並解析 Intro 內容

影響範圍：
- 企業計畫詳情頁面現在能正確顯示體驗介紹、師資介紹、參加限制、行前須知等解析後的結構化內容
- 申請統計資料（TotalApplicants, ReviewedCount, PendingCount）正常顯示
- 所有計畫基本資訊欄位正確對應

技術細節：
- 統一使用 PascalCase 欄位名稱以匹配後端 API
- 保持前端介面的一致性，避免欄位名稱混用
- 確保型別安全性和運行時資料正確性