### PR TITLE
feat(company): add participant_id field to applicant data flow

### DIFF
--- a/composables/api/company/useApplicant.ts
+++ b/composables/api/company/useApplicant.ts
@@ -14,8 +14,8 @@ export const useApplicant = (
     // 當 companyId 為空時，返回 null，不發送請求
     if (!resolvedCompanyId || !resolvedProgramId || !resolvedApplicantId) return null;
     
-    // 根據 e comp 8 的 API 規範，單一申請者詳情使用 programs 端點
-    return `/api/v1/programs/${resolvedProgramId}/applicantions/${resolvedApplicantId}`;
+    // 根據 e comp 8 的 API 規範，單一申請者詳情使用 company 端點
+    return `/api/v1/company/${resolvedCompanyId}/programs/${resolvedProgramId}/applications/${resolvedApplicantId}`;
   });
 
   return useCompanyApiFetch<ApplicantDetail>(url, {

--- a/composables/api/company/useApplicants.ts
+++ b/composables/api/company/useApplicants.ts
@@ -7,12 +7,14 @@ export interface ApplicantsListResponse {
     PendingCount: number;
   };
   PendingApplications: Array<{
+    participant_id: number;
     applicant_name: string;
     identity: number;
     submit_date: string;
     review_status: string;
   }>;
   ReviewedApplications: Array<{
+    participant_id: number;
     applicant_name: string;
     identity: number;
     submit_date: string;

--- a/pages/company/programs/[programId]/applicants/index.vue
+++ b/pages/company/programs/[programId]/applicants/index.vue
@@ -111,7 +111,7 @@ const approvedStatus = ref('all')
             <NuxtLink
               :to="{
                 name: 'company-program-applicant-detail',
-                params: { programId: route.params.programId, applicantId: row.identity },
+                params: { programId: route.params.programId, applicantId: row.participant_id },
               }"
             >
               <el-button type="primary">
@@ -182,7 +182,7 @@ const approvedStatus = ref('all')
             <NuxtLink
               :to="{
                 name: 'company-program-applicant-detail',
-                params: { programId: route.params.programId, applicantId: row.identity },
+                params: { programId: route.params.programId, applicantId: row.participant_id },
               }"
             >
               <el-button type="primary">


### PR DESCRIPTION
新增 participant_id 欄位至申請者資料流，確保 e comp 7 與 e comp 8 之間的資料傳遞正確性。

決策：
- 在 ApplicantsListResponse 型別定義中新增 participant_id 欄位
- 將申請者列表頁面的路由參數從 identity 改為 participant_id
- 修正 useApplicant composable 的 API 端點路徑

理由：
- 解決 e comp 7 API 回應中的 participant_id 欄位無法正確傳遞至 e comp 8 的問題
- 統一資料流：e comp 7 取得 participant_id → 列表頁面使用 participant_id 作為路由參數 → e comp 8 使用 participant_id 作為 API 參數
- 修正 API 端點路徑拼寫錯誤（applicantions → applications）並加入遺漏的 company 路徑段

影響範圍：
- 型別定義：ApplicantsListResponse 介面
- 申請者列表頁面：路由參數傳遞
- API composable：端點路徑修正

此修改確保申請者審核流程的資料一致性，為後續 e comp 8 功能提供正確的 participant_id 參數。