### PR TITLE
feat(company-comments): 增加偵錯日誌與載入/錯誤狀態；API 增加請求日誌

### DIFF
--- a/composables/api/company/useCompanyCommentReviews.ts
+++ b/composables/api/company/useCompanyCommentReviews.ts
@@ -14,8 +14,19 @@ export const useCompanyCommentReviews = () => {
     const qs = query.toString();
 
     const url = `/api/v1/company/${companyId}/evaluations${qs ? `?${qs}` : ''}`;
+    console.info('[API] about to fetch', url)
 
-    const { data, error } = await useCompanyApiFetch<CompanyEvaluationListResponse>(url, { method: 'GET' });
+    const { data, error } = await useCompanyApiFetch<CompanyEvaluationListResponse>(url, {
+      method: 'GET',
+      onRequest(ctx) {
+        try {
+          const hdr = ctx.options?.headers instanceof Headers
+            ? Object.fromEntries((ctx.options.headers as Headers).entries())
+            : ctx.options?.headers;
+          console.info('➡️ request', String(ctx.request), hdr)
+        } catch {}
+      }
+    });
 
     return { data, error };
   };


### PR DESCRIPTION
背景：
- 從 Gmail 超連結進入評價頁時，畫面呈現空白且 Network 未出現評價列表請求，缺乏觀測訊息不易定位。

決策：
- 不更動商業邏輯，先強化可觀測性與使用者回饋。
- 在頁面 onMounted 與 loadData 前後輸出日誌（isLoggedIn、companyId、token 是否存在、page/limit）。
- 在 useCompanyCommentReviews 透過 onRequest 輸出「➡️ request」與 headers。
- 於頁面加入 loading 與 loadError 狀態，避免使用者只見空白。

理由：
- 快速判斷是「請求未送出」、「認證/權限問題」或「後端回零筆」，提升郵件深連結進站情境下的除錯效率。

其他：
- 不改動 API 路徑、授權流程與既有 UI 版型；保留開發用 companyId=9 fallback。
- 日誌以 [Comments]/[API] 前綴，便於篩選與閱讀。