### PR TITLE
fix(company-comments): 修正深連結進站後評價列表不顯示

### DIFF
--- a/pages/company/comments/index.vue
+++ b/pages/company/comments/index.vue
@@ -63,7 +63,14 @@ async function loadData() {
         id: item.Id,
         author: {
           name: item.ParticipantName,
-          avatar: item.Headshot || '',
+          // 修正後端回傳的 http 與檔名空白，避免 Mixed Content 與 404
+          avatar: (() => {
+            const raw = item.Headshot || ''
+            if (!raw) return ''
+            // 升級為 https 並處理空白
+            const upgraded = raw.replace(/^http:\/\//i, 'https://')
+            return encodeURI(upgraded)
+          })(),
           role: item.ParticipantIdentity?.title || '—',
           age: item.ParticipantAge
         },


### PR DESCRIPTION
- 改以瀏覽器端 $fetch 發送 GET /api/v1/company/{id}/evaluations，附 Authorization，避免在 SSR 階段 token 尚未就緒導致請求被跳過，且 hydration 時不再重發而造成空白清單
- 新增頁面偵錯日誌與載入/錯誤/空狀態，提升可觀測性與回饋
- 強化 useCompanyApiFetch：輸出 baseURL、token 概要與 onRequest/onResponse/onResponseError 日誌
- 優化頭像連結：統一升級為 https 並以 encodeURI 處理檔名空白，降低 Mixed Content 與 404

決策：保持現有 API 與路由不變，僅對需授權清單採 client-only 取數；必要時可改回 useFetch 並設 server:false。 理由：Gmail 深連結初次進頁會先跑 SSR，因認證時序導致資料未取且被去重。
其他：不影響未授權頁；圖片缺檔時仍有預設頭像 fallback。