### PR TITLE
fix(users/comments): 使用 evaluation_at 作為評價日期並顯示時分秒，修復 Invalid Date

### DIFF
--- a/pages/users/comments/index.vue
+++ b/pages/users/comments/index.vue
@@ -33,6 +33,14 @@ function resolveCompanyLogo(rawLogoPath?: string | null): string | undefined {
   return encodeURI(proxied);
 }
 
+// 日期格式化
+const { $dayjs } = useNuxtApp();
+function formatEvaluationDate(dateStr?: string | null): string {
+  if (!dateStr) return '';
+  const d = $dayjs(dateStr);
+  return d.isValid() ? d.format('YYYY/MM/DD HH:mm:ss') : '';
+}
+
 // 篩選器狀態
 const statusOptions = ['審核中', '系統已通過', '系統已拒絕', '人工已通過', '人工已拒絕', '待處理', '已發布', '全部通過', '全部拒絕', '未評價'];
 const selectedStatuses = ref<string[]>([]);
@@ -349,7 +357,7 @@ onMounted(() => {
         <div v-if="item.status_id !== 17" class="mt-3 flex items-center gap-4 text-gray-600">
           <el-rate :model-value="item.score || 0" disabled />
           <span class="font-semibold">{{ (item.score || 0).toFixed(1) }}</span>
-          <span class="text-gray-400">{{ new Date(item.evaluation_date).toLocaleDateString() }}</span>
+          <span class="text-gray-400">{{ formatEvaluationDate(item.evaluation_at) || '-' }}</span>
           <el-tag :type="tagTypeForStatus(statusIdToText(item.status_id))" size="small" effect="plain">
             {{ statusIdToText(item.status_id) }}
           </el-tag>

--- a/types/users/comment.ts
+++ b/types/users/comment.ts
@@ -13,7 +13,7 @@ export interface ReviewItem {
   program_end_date: string;
   company_name: string;
   company_logo: string;
-  evaluation_date: string;
+  evaluation_at: string;
 }
 
 export interface CommentsQueryParams {


### PR DESCRIPTION
本次主旨摘要:
- 調整用戶評價列表日期欄位來源為 evaluation_at，統一以 dayjs 格式化顯示 YYYY/MM/DD HH:mm:ss，消除 Invalid Date。

決策:
- 更新 types/users/comment.ts 的 ReviewItem，將 evaluation_date 更名為 evaluation_at，與 API 回應一致。
- 在 pages/users/comments/index.vue 新增 formatEvaluationDate，以 dayjs 驗證與格式化；渲染改用 item.evaluation_at，無效值顯示 -。
- 保留 Element Plus 預設樣式，不調整 UI 排版。

理由:
- 原生 Date 對 ISO/UTC 字串解析存在差異，易產生 Invalid Date；統一以 dayjs 處理可提升穩定性與可讀性。
- 加入時分秒以回應設計需求，避免資訊缺漏。

其他補充:
- 僅更動型別與畫面渲染，不影響資料流、權限與 API 呼叫；影響範圍可控，回滾容易。