### PR TITLE
fix(ci): 修復 pnpm 版本衝突問題

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: 安裝 pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.9.0
+        version: latest
         
     - name: 安裝依賴
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
將 GitHub Actions 中的 pnpm 版本設定改為 latest，
讓系統自動使用 package.json 中 packageManager 欄位指定的版本，
避免多版本衝突導致的安裝失敗。

修復後工作流程應該能正常執行所有檢查步驟。