### PR TITLE
fix(ci): 修正圖片優化配置解決預渲染 500 錯誤

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -79,13 +79,13 @@ export default defineNuxtConfig({
 			'/api-proxy/**': {
 				proxy: 'https://trybeta.rocket-coding.com/**',
 			},
-			// 靜態圖與 IPX 輸出的長時間快取（提升重訪/多頁載入速度）
+			// 靜態圖與 Vercel 圖片輸出的長時間快取（提升重訪/多頁載入速度）
 			'/img/**': {
 				headers: {
 					'cache-control': 'public, max-age=31536000, immutable',
 				},
 			},
-			'/_ipx/**': {
+			'/_vercel/image/**': {
 				headers: {
 					'cache-control': 'public, max-age=31536000, immutable',
 				},
@@ -118,6 +118,8 @@ export default defineNuxtConfig({
 				'/users/login',
 				'/users/register',
 			],
+			// 添加預渲染錯誤處理，忽略圖片優化請求
+			ignore: ['/_vercel/image/**', '/_ipx/**'],
 		},
 		// Vercel 部署優化
 		...(process.env.VERCEL && {
@@ -143,8 +145,8 @@ export default defineNuxtConfig({
 		// 圖片格式和品質設定
 		format: ['webp'],
 		quality: 80,
-		// 根據環境選擇提供者
-		provider: process.env.VERCEL ? 'vercel' : 'ipx',
+		// 修正：統一使用 Vercel 提供者，避免 IPX 在預渲染時的問題
+		provider: 'vercel',
 		// 允許優化的外部域名
 		domains: ['trybeta.rocket-coding.com', 'images.unsplash.com', 'i.imgur.com'],
 		// 定義所有可能的螢幕尺寸（Vercel 需要）
@@ -156,6 +158,11 @@ export default defineNuxtConfig({
 			'xl': 1280,
 			'xxl': 1536,
 			'2xl': 1536,
+		},
+		// 添加 Vercel 特定配置
+		vercel: {
+			// 確保在 Vercel 環境下正確處理圖片
+			baseURL: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
 		},
 	},
 

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,12 @@
       "headers": {
         "cache-control": "public, max-age=31536000, immutable"
       }
+    },
+    {
+      "src": "/_vercel/image/(.*)",
+      "headers": {
+        "cache-control": "public, max-age=31536000, immutable"
+      }
     }
   ],
   "build": {


### PR DESCRIPTION
統一使用 Vercel 圖片優化服務，避免 IPX 在預渲染階段的衝突：
- 將圖片提供者從環境判斷改為統一使用 'vercel'
- 更新 vercel.json 添加 _vercel/image 路由快取規則
- 修正 nitro 配置中的圖片快取路徑從 _ipx 改為 _vercel/image
- 添加預渲染忽略規則，避免處理圖片優化請求

此修正解決了 CI/CD 中所有 _ipx 路徑的 500 錯誤，
確保預渲染過程順利完成，同時保持圖片優化效能。

影響範圍：
- 18 個圖片使用點（包含 5 個外部 Unsplash 圖片）
- 首頁 LCP 關鍵資源優化
- 響應式圖片和 WebP 格式轉換