### PR TITLE
git commit -m "fix(company): 修正 NotifyURL 網域並增強付款回調除錯功能

### DIFF
--- a/docs/newebpay-backend-aspnet-guide.md
+++ b/docs/newebpay-backend-aspnet-guide.md
@@ -112,11 +112,11 @@ public async Task<IActionResult> CreatePayment([FromBody] PaymentRequest request
         ["Amt"] = order.Amount.ToString(),
         ["ItemDesc"] = GetPlanDescription(request.PlanId),
         
-        // ✅ 正確：指向前端的 API endpoint（前端已實作）
-        ["ReturnURL"] = "https://try-b.vercel.app/api/v1/company/payments/return",
-        
-        // ✅ 正確：指向後端的 API endpoint（後端需實作）
-        ["NotifyURL"] = "https://try-b.vercel.app/api/v1/payments/callback",
+    // ✅ 正確：指向前端的 API endpoint（前端已實作）
+    ["ReturnURL"] = "https://try-b.vercel.app/api/v1/company/payments/return",
+    
+    // ✅ 正確：指向後端的 API endpoint（後端需實作）
+    ["NotifyURL"] = "https://trybeta.rocket-coding.com/api/v1/payments/callback",
         
         ["Email"] = GetCompanyEmail(request.CompanyId),
         

--- a/docs/newebpay-implementation-summary.md
+++ b/docs/newebpay-implementation-summary.md
@@ -79,7 +79,7 @@ var tradeInfo = new Dictionary<string, string>
     ["ReturnURL"] = "https://try-b.vercel.app/api/v1/company/payments/return",
     
     // ✅ 關鍵修改 2：NotifyURL 改為後端 API endpoint
-    ["NotifyURL"] = "https://try-b.vercel.app/api/v1/payments/callback",
+    ["NotifyURL"] = "https://trybeta.rocket-coding.com/api/v1/payments/callback",
     
     ["Email"] = company.Email,
     // ... 其他參數

--- a/docs/newebpay-integration.md
+++ b/docs/newebpay-integration.md
@@ -168,7 +168,7 @@ var tradeInfo = new Dictionary<string, string>
     // ⬇️ 必須設置為前端 API endpoint（前端已實作）
     ["ReturnURL"] = "https://try-b.vercel.app/api/v1/company/payments/return",
     // ⬇️ 必須設置為後端 API endpoint（後端需實作）
-    ["NotifyURL"] = "https://try-b.vercel.app/api/v1/payments/callback",
+    ["NotifyURL"] = "https://trybeta.rocket-coding.com/api/v1/payments/callback",
     ["Email"] = "company@example.com",
     // ... 其他參數
 };

--- a/ticket.md
+++ b/ticket.md
@@ -60,7 +60,7 @@ var tradeInfo = new Dictionary<string, string>
     // ⬇️ 關鍵修改：ReturnURL 改為前端 API endpoint
     ["ReturnURL"] = "https://try-b.vercel.app/api/v1/company/payments/return",
     // NotifyURL 改為後端 API endpoint
-    ["NotifyURL"] = "https://try-b.vercel.app/api/v1/payments/callback",
+    ["NotifyURL"] = "https://trybeta.rocket-coding.com/api/v1/payments/callback",
     ["Email"] = company.Email,
     // ... 其他參數
 };


### PR DESCRIPTION
修正藍新金流 NotifyURL 設定並增加詳細除錯日誌：
- 修正所有文檔中 NotifyURL 網域為正確的後端網址
- 增強 success 頁面增加 console 調試日誌
- 新增藍新金流狀態判斷邏輯 (isNewebpaySuccess)
- 改善錯誤處理提供更明確的錯誤訊息" \ -m "決策：
1. NotifyURL 必須指向真實後端伺服器 (trybeta.rocket-coding.com) 而非前端 Vercel 部署，因為是伺服器對伺服器的背景通知
2. ReturnURL 維持指向前端 Vercel 的 API endpoint 用於用戶瀏覽器的前景通知和頁面跳轉
3. 增加詳細的 console 日誌協助定位付款回調問題" \ -m "理由：
NotifyURL 是藍新金流伺服器直接通知後端的端點，
必須指向後端 ASP.NET 伺服器 (https://trybeta.rocket-coding.com) 而不是前端 Nuxt 伺服器。ReturnURL 則是用戶瀏覽器跳轉，
指向前端 Vercel 部署的 server endpoint 處理後重定向到成功頁面。
增加調試日誌可以在正式環境快速定位訂單編號傳遞問題。" \
-m "其他補充：
- 修正文檔：newebpay-backend-aspnet-guide.md
- 修正文檔：newebpay-implementation-summary.md
- 修正文檔：newebpay-integration.md
- 增強：success.vue 新增 newebpayStatus、isNewebpaySuccess 判斷
- 更新：ticket.md 記錄 NotifyURL 網域修正

準備在正式環境測試完整付款流程並驗證回調機制。"