### PR TITLE
fix(payments): 解決藍新金流結帳結果 API 404 錯誤

### DIFF
--- a/server/api/v1/company/payments/result.get.ts
+++ b/server/api/v1/company/payments/result.get.ts
@@ -39,8 +39,8 @@ export default createApiHandler(async (event) => {
 			orderNum: orderNum,
 		});
 
-		// 呼叫 ASP.NET 後端 API (使用 GET 方法)
-		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('/api-proxy/api/v1/payments/result', {
+		// 呼叫 ASP.NET 後端 API (使用直連方式)
+		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('https://trybeta.rocket-coding.com/api/v1/payments/result', {
 			method: 'GET',
 			headers: getForwardHeaders(event),
 			query: { orderNum },

--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -33,41 +33,37 @@ export default createApiHandler(async (event) => {
 			return {
 				status: 'Failed',
 				error: '缺少 TradeInfo 或 TradeSha 參數',
+				orderNo: '',
+				amount: '',
+				paymentMethod: 'CREDIT',
 			};
 		}
-
-		// 準備請求資料
-		const requestData = {
-			TradeInfo: TradeInfo as string,
-			TradeSha: TradeSha as string,
-		};
 
 		console.log('[結帳結果 API] 準備向 ASP.NET 後端請求:', {
 			tradeInfoLength: (TradeInfo as string).length,
 			tradeShaLength: (TradeSha as string).length,
 		});
 
-		// 呼叫 ASP.NET 後端 API (使用 POST 方法)
-		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('/api-proxy/api/v1/payments/result', {
+		// 呼叫 ASP.NET 後端 API (使用直連方式)
+		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('https://trybeta.rocket-coding.com/api/v1/payments/result', {
 			method: 'POST',
 			headers: getForwardHeaders(event),
-			body: requestData,
+			body: {
+				TradeInfo: TradeInfo as string,
+				TradeSha: TradeSha as string,
+			},
 		});
 
 		console.log('[結帳結果 API] ASP.NET 後端回應:', response);
 
-		// 格式化回應資料以符合前端需求
-		const formattedResponse: PaymentResultResponse = {
+		// 直接返回後端回應，確保格式一致
+		return {
 			status: response.status || 'Failed',
 			orderNo: response.orderNo || '',
 			amount: response.amount || '',
 			paymentMethod: response.paymentMethod || 'CREDIT',
 			card4No: response.card4No || undefined,
 		};
-
-		console.log('[結帳結果 API] 格式化回應:', formattedResponse);
-
-		return formattedResponse;
 	}
 	catch (error) {
 		console.error('[結帳結果 API] 處理錯誤:', error);


### PR DESCRIPTION
將 ASP.NET 後端調用從代理模式改為直連方式，
修正錯誤回應格式並優化代碼邏輯。

決策:
- 將 result.post.ts 和 result.get.ts 的代理調用 改為直接連接 https://trybeta.rocket-coding.com
- 修正錯誤回應格式，補齊必要欄位 (orderNo, amount, paymentMethod)
- 移除多餘的 requestData 變數，簡化代碼結構
- 直接返回後端回應，確保格式一致性

理由:
ASP.NET 後端 /api/v1/payments/result 端點通過代理調用時出現 404， 但其他 API 端點使用相同代理配置均正常運作。
Postman 直連測試確認後端端點存在且可達，
問題根源在於 Vercel 環境中的代理配置限制。

其他補充:
- 符合 e-comp-12-3 規格書要求使用 POST 方法
- 保持與現有付款流程的相容性
- 解決 success.vue 頁面停滯在「處理中」狀態的問題