### PR TITLE
feat(api): 調整結帳結果 API 使用代理方式串接後端

### DIFF
--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -44,14 +44,17 @@ export default createApiHandler(async (event) => {
 			tradeShaLength: (TradeSha as string).length,
 		});
 
-		// 呼叫 ASP.NET 後端 API (使用直連方式)
-		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('https://trybeta.rocket-coding.com/api/v1/payments/result', {
+		// 呼叫 ASP.NET 後端 API (使用代理方式，x-www-form-urlencoded 格式)
+		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('/api-proxy/api/v1/payments/result', {
 			method: 'POST',
-			headers: getForwardHeaders(event),
-			body: {
+			headers: {
+				...getForwardHeaders(event),
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
 				TradeInfo: TradeInfo as string,
 				TradeSha: TradeSha as string,
-			},
+			}),
 		});
 
 		console.log('[結帳結果 API] ASP.NET 後端回應:', response);


### PR DESCRIPTION
決策: 將直連 ASP.NET 後端改為透過 Nuxt 代理，並確保請求格式為 x-www-form-urlencoded

理由:
- 解決 400 Bad Request 錯誤，ASP.NET 後端需要特定 Content-Type 格式
- 維持 BFF 架構一致性，避免前端直接呼叫外部 API
- 透過代理統一處理認證與錯誤處理邏輯

其他補充:
- 保持 application/x-www-form-urlencoded 格式確保與後端相容性
- 使用 URLSearchParams 正確編碼請求參數
- 維持原有的錯誤處理與日誌記錄機制