### PR TITLE
fix(api): 修正結帳結果 API 代理連接問題，改為直連 ASP.NET 後端

### DIFF
--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -44,11 +44,10 @@ export default createApiHandler(async (event) => {
 			tradeShaLength: (TradeSha as string).length,
 		});
 
-		// 呼叫 ASP.NET 後端 API (使用代理方式，x-www-form-urlencoded 格式)
-		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('/api-proxy/api/v1/payments/result', {
+		// 呼叫 ASP.NET 後端 API (直接呼叫，x-www-form-urlencoded 格式)
+		const response: PaymentResultResponse = await event.$fetch<PaymentResultResponse>('https://trybeta.rocket-coding.com/api/v1/payments/result', {
 			method: 'POST',
 			headers: {
-				...getForwardHeaders(event),
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
 			body: new URLSearchParams({


### PR DESCRIPTION
決策: 將 Nuxt BFF 呼叫 ASP.NET 後端的方式從代理改為直接連接

理由:
- 解決 502 Bad Gateway 錯誤，代理設定無法正確轉發請求
- Postman 測試確認 ASP.NET 後端端點可直接訪問
- 簡化請求流程，移除不必要的代理層級

其他補充:
- 移除 getForwardHeaders 以簡化請求標頭
- 維持 application/x-www-form-urlencoded 格式確保後端相容性
- 為後續統一 API 請求策略奠定基礎
- 問題根源在代理配置而非後端服務可用性