### PR TITLE
fix(api): 修正付款結果 API 回應格式與 Postman 不一致問題

### DIFF
--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -66,8 +66,8 @@ export default createApiHandler(async (event) => {
 			status: response.status || 'Failed',
 			orderNo: response.orderNo || '',
 			amount: response.amount || '',
-			paymentMethod: response.paymentMethod || 'CREDIT',
-			card4No: response.card4No || undefined,
+			paymentMethod: response.paymentMethod || '',
+			card4No: response.card4No || '',
 		};
 	}
 	catch (error) {
@@ -83,7 +83,8 @@ export default createApiHandler(async (event) => {
 			status: 'Failed',
 			orderNo: '',
 			amount: '',
-			paymentMethod: 'CREDIT',
+			paymentMethod: '',
+			card4No: '',
 		};
 	}
 });


### PR DESCRIPTION
修正 Postman 與前端環境 API 回應欄位不一致的關鍵問題：
- 統一 paymentMethod 預設值處理邏輯
- 修正 card4No 欄位預設值從 undefined 改為空字串
- 確保錯誤處理回應格式與成功回應格式完全一致

決策：採用直接呼叫外部 ASP.NET 後端 API 取代代理轉發，
      並統一所有回應欄位的預設值處理邏輯

理由：Postman 測試顯示外部 API 正常返回 status: "Failed"
      且包含完整訂單資訊，但前端收到 status: "Error"
      且欄位為空，確認問題出在 API 回應格式處理不一致

其他補充：影響 POST 付款結果查詢端點，
         確保藍新金流整合的回應格式一致性，
         解決前端 UI 狀態顯示與實際 API 回應不符的問題