### PR TITLE
refactor(payments): 移除手動 Header 設定統一使用 createAuthHeaders

### DIFF
--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -19,7 +19,7 @@ interface PaymentResultResponse {
 export default createApiHandler(async (event) => {
 	try {
 		// 強制診斷日誌 - 確認線上版本
-		console.log('[診斷] result.post.ts 版本: v2025-01-09-直接連線ASP.NET後端');
+		console.log('[診斷] result.post.ts 版本: v2025-01-09-移除手動Header設定');
 
 		// 取得請求主體
 		const body = await readBody(event);
@@ -58,10 +58,6 @@ export default createApiHandler(async (event) => {
 				statusMessage: '請登入',
 			});
 		}
-
-		// 添加必要的 Content-Type
-		headers['Content-Type'] = 'application/json; charset=utf-8';
-		headers['Accept'] = 'application/json';
 
 		// 詳細記錄請求內容
 		const requestBody = {


### PR DESCRIPTION
決策：
移除 result.post.ts 中手動設定 Content-Type 和 Accept 的程式碼， 完全依賴 createAuthHeaders 和 $fetch 的自動處理機制。

理由：
1. 統一編程風格：與其他 API 端點（index.get.ts、industries.get.ts） 保持一致，這些端點都沒有手動設定 Content-Type 和 Accept
2. 避免 Header 重複定義：createAuthHeaders 已從 incoming request 複製必要的 headers，手動添加會造成重複（小寫 content-type 與大寫駝峰 Content-Type 同時存在）
3. 利用 $fetch 自動處理：當 body 為物件時，$fetch 會自動設定 Content-Type: application/json 並序列化 JSON
4. 排查 415 錯誤：移除可能導致 ASP.NET 後端解析錯誤的重複 headers

其他補充：
- 保持直接連線 ASP.NET 後端（繞過 /api-proxy 代理轉發）
- 維持完整的錯誤揭露機制和詳細請求日誌
- 版本標記更新為 v2025-01-09-移除手動Header設定
- 此修改解決了 Vercel Function 向 ASP.NET 後端發送請求時 因 Header 重複定義導致的 415 Unsupported Media Type 錯誤