### PR TITLE
refactor(api): 更新藍新金流 ReturnURL 端點註解說明真實用途

### DIFF
--- a/server/api/v1/company/payments/return.post.ts
+++ b/server/api/v1/company/payments/return.post.ts
@@ -3,14 +3,19 @@ import { createApiHandler } from '~/server/utils/apiHandler';
 /**
  * 藍新金流 ReturnURL 端點 (BFF 代理重定向)
  *
- * 用途：當 ASP.NET 後端需要重定向到前端時，可以透過此端點
+ * 用途：處理藍新金流付款完成後的瀏覽器重定向請求
  *
  * 流程：
- * 1. 藍新金流 → ASP.NET 後端 Return URL
- * 2. ASP.NET 後端 → BFF return.post.ts (此檔案)
- * 3. BFF → 前端 success 頁面
+ * 1. 藍新金流 → 此端點 (POST 請求，包含 TradeInfo, TradeSha, Status)
+ * 2. 此端點 → 重定向到前端 success 頁面 (GET 請求，URL 參數)
+ * 3. 前端頁面 → 渲染 Loading UI，同時請求 result API 取得完整資料
+ * 4. 前端頁面 → 渲染完整付款結果 UI
  *
- * 這樣可以避免跨網域重定向的問題
+ * 設計理念：
+ * - 此端點只負責重定向，不做業務邏輯處理
+ * - 前端頁面負責 UI 展示和資料請求
+ * - 後端 API 負責資料處理和業務邏輯
+ * - 避免在 URL 中暴露敏感資料，改為透過 API 請求取得
  */
 export default createApiHandler(async (event) => {
 	try {


### PR DESCRIPTION
決策: 修正 return.post.ts 頂端註解內容，準確反映檔案在付款流程中的實際角色

理由:
  - 原註解內容與實際功能不符，容易造成開發者誤解
  - 需要清楚說明此端點負責處理藍新金流瀏覽器重定向請求
  - 明確描述從 POST 請求到 GET 重定向的完整流程
  - 強調職責分離：端點只負責重定向，不做業務邏輯處理

其他補充:
  - 更新流程說明：藍新金流 → 此端點 → 前端頁面
  - 說明設計理念：避免在 URL 中暴露敏感資料
  - 前端頁面負責 UI 展示和資料請求
  - 後端 API 負責資料處理和業務邏輯
  - 保持與整體架構設計的一致性

此更新提升程式碼可讀性，幫助開發者正確理解端點用途。