### PR TITLE
refactor(api): 優化藍新金流架構並更新後端支援能力記錄

### DIFF
--- a/server/api/v1/company/payments/result.post.ts
+++ b/server/api/v1/company/payments/result.post.ts
@@ -88,12 +88,16 @@ export default createApiHandler(async (event) => {
 			});
 		}
 
-		// 詳細記錄請求內容 - 加入 OrderNo 欄位
-		const requestBody = {
-			OrderNo: finalOrderNo,
+		// 詳細記錄請求內容 - 完全省略 OrderNo 屬性
+		const requestBody: any = {
 			TradeInfo: TradeInfo as string,
 			TradeSha: TradeSha as string,
 		};
+
+		// 只有在 OrderNo 存在且不為空時才加入
+		if (finalOrderNo && finalOrderNo.trim() !== '') {
+			requestBody.OrderNo = finalOrderNo;
+		}
 
 		console.log('[結帳結果 API] 準備發送的 Headers:', headers);
 		console.log('[結帳結果 API] 完整 TradeInfo 長度:', (TradeInfo as string).length);

--- a/types/company/payment.ts
+++ b/types/company/payment.ts
@@ -40,7 +40,7 @@ export interface PaymentResultResponse {
 
 // 結帳結果請求 (POST /api/v1/payments/result)
 export interface PaymentResultRequest {
-	OrderNo: string
+	OrderNo?: string // 可選屬性，讓後端處理 OrderNo 提取
 	TradeInfo: string
 	TradeSha: string
 }


### PR DESCRIPTION
決策: 根據 Postman 測試成功結果，簡化 BFF 層的 OrderNo 處理邏輯，
      完全省略 OrderNo 屬性傳遞，讓 ASP.NET 後端自行處理解密與提取

理由:
  - Postman 測試顯示後端能成功處理 TradeInfo 和 TradeSha
  - 後端能自行從 TradeInfo 解密提取 OrderNo (ORD20251010004)
  - 移除前端修剪邏輯避免資料完整性損毀
  - 後端已升級支援完整解析 1024*8 位元長度的資料

其他補充:
  - 修改 server/api/v1/company/payments/result.post.ts 省略空 OrderNo 屬性
  - 更新 server/api/v1/company/payments/return.post.ts 簡化重定向邏輯並記錄後端支援能力
  - 調整 types/company/payment.ts 將 OrderNo 改為可選屬性
  - 移除 composables/api/company/useCompanyPayment.ts 中的 TradeInfo 修剪邏輯
  - 解決 ASP.NET 後端 "Index was outside the bounds of the array" 錯誤
  - 確保 1024*8 位元 TradeInfo 完整傳輸，保持資料完整性
  - 更新系統記錄反映後端完整支援 8192 位元資料解析能力

此重構成功解決付款流程問題，提升系統穩定性與資料完整性。