### PR TITLE
refactor(company): 重構藍新金流重定向機制實現完整結帳流程

### DIFF
--- a/pages/company/purchase/success.vue
+++ b/pages/company/purchase/success.vue
@@ -158,7 +158,6 @@
 				</el-button>
 			</div>
 		</div>
-
 	</div>
 </template>
 


### PR DESCRIPTION
決策：
- 將 return.post.ts 從數據查詢端點改為重定向端點
- 移除向後相容轉換邏輯，直接使用新版 API 格式 (Success/Failed/Pending)
- 移除未使用的測試函數和輪詢機制
- 更新 PaymentResultResponse 介面支援新格式

理由：
1. 解決藍新金流回調後瀏覽器直接顯示 JSON 而非重定向到 success.vue 的問題
2. 實現標準的 Return URL 行為：藍新金流 → return.post.ts → success.vue
3. 簡化架構：重定向端點負責跳轉，前端頁面負責數據查詢和 UI 渲染
4. 新版 API 已穩定，不再需要向後相容的複雜轉換邏輯
5. 移除約 350+ 行未使用或冗餘程式碼，提升維護性

其他補充：
- return.post.ts 現在使用 sendRedirect 重定向到 success.vue 並傳遞 URL 參數
- success.vue 保持完整的參數接收和結帳結果查詢邏輯
- 所有 TypeScript 類型檢查通過，無 linter 錯誤
- 實現完整流程：藍新金流 → 重定向 → 查詢數據 → 渲染 UI