### PR TITLE
fix(api): 強化評價提交 API 的認證機制

### DIFF
--- a/server/api/v1/users/[userId]/programs/[programId]/evaluations.put.ts
+++ b/server/api/v1/users/[userId]/programs/[programId]/evaluations.put.ts
@@ -15,8 +15,17 @@ export default createApiHandler(async (event) => {
 	// 讀取請求體
 	const body = await readBody(event);
 
-	// 使用統一的 headers 處理（提交評價需要認證）
-	const headers = getForwardHeaders(event);
+	// 修正：從 cookie 取得用戶認證 token
+	const userToken = getCookie(event, 'userAuthToken');
+	if (!userToken) {
+		throw createError({
+			statusCode: 401,
+			statusMessage: 'Unauthorized: Missing authentication token',
+		});
+	}
+
+	// 使用統一的 headers 處理，並傳入 token
+	const headers = getForwardHeaders(event, userToken);
 
 	// 透過 Nitro 的 proxy 設定轉發到真實後端
 	// 規則：必須包含 api 並使用 /api-proxy 進行代理


### PR DESCRIPTION
決策：
在 BFF 層添加明確的 token 驗證邏輯，確保用戶認證 token
正確轉發至後端 API，解決評價提交的 400 Bad Request 問題。

理由：
1. 原實作僅使用 getForwardHeaders(event) 而未明確處理認證 token
2. 後端 API 需要 Authorization header 進行身份驗證
3. 缺少 token 驗證導致請求被後端拒絕，回傳 400 錯誤

變更內容：
- 添加 userAuthToken cookie 檢查機制
- 將 token 明確傳入 getForwardHeaders 函數
- 新增 401 Unauthorized 錯誤處理

影響範圍：
- server/api/v1/users/[userId]/programs/[programId]/evaluations.put.ts

此修正確保評價提交請求能正確通過後端認證檢查，
提升 API 請求的成功率與安全性。