### PR TITLE
refactor(auth): 替換 Element Plus 按鈕為原生按鈕避免樣式衝突並補上 git

### DIFF
--- a/components/auth/GoogleLoginButton.vue
+++ b/components/auth/GoogleLoginButton.vue
@@ -72,7 +72,7 @@
 			>
 				更換其他帳號登入/註冊
 			</button>
-			
+
 			<!-- 清除登入記錄選項 -->
 			<button
 				:disabled="isLoading"
@@ -159,20 +159,20 @@ const handleClearLoginRecord = async () => {
 				type: 'warning',
 			},
 		)
-		
+
 		// 清除 Google 的登入記錄
 		if (import.meta.client) {
 			// 清除本地儲存的 Google 登入狀態
 			localStorage.removeItem('google_auth_state')
 			sessionStorage.removeItem('google_auth_state')
-			
+
 			// 清除所有 Google 相關的儲存
 			localStorage.removeItem('g_state')
 			sessionStorage.removeItem('g_state')
 		}
-		
+
 		ElMessage.success('登入記錄已清除')
-		
+
 		// 重新載入頁面以重新初始化 Google 登入
 		window.location.reload()
 	}


### PR DESCRIPTION
add

將 GoogleLoginButton 組件中的 el-button 替換為原生 button 元素， 並使用 Tailwind CSS 類別實現載入狀態動畫：

決策:
- 遵循 Element Plus 文檔建議，避免與 Tailwind CSS 混用
- 保持與上方登入按鈕的視覺一致性
- 使用原生元素確保樣式控制權

理由:
- Element Plus 內建樣式與 Tailwind CSS 產生衝突
- 原生 button 提供更精確的樣式控制
- 載入狀態需要自定義實現，原生元素更靈活

其他補充:
- 實現自定義載入動畫（旋轉圖示）
- 載入時顯示「登入中…」文字並禁用按鈕
- 維持相同的 hover 效果和過渡動畫