### PR TITLE
docs(readme): 重構專案說明文件以提升可讀性與專業度

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,207 +1,184 @@
-## TRY β 職業體驗平台
+# 🚀 TRY β 職業體驗平台
 
-一個連結人才與企業的職業體驗平台，提供多元的短期體驗計畫，協助使用者在投入職場前探索興趣、找到適合的道路。
-
-### 專案成果
-
-**1. 完成了什麼任務？**
-- **兩端完整系統開發**：建構體驗者端、企業端端兩個獨立但整合的系統
-- **職業體驗平台核心功能**：實現先體驗後聘用的創新求職模式
-- **全端 Web 應用程式**：從前端 UI 到後端 API 的完整開發與部署 (開發模式屬於前、後端分離)
-- **響應式設計實現**：支援桌機、平板、手機等多裝置體驗
-
-**2. 開發過程中解決了什麼問題？**
-- **跨端權限管理**：解決不同角色（體驗者、企業、管理員）的權限控制與路由保護
-- **API 架構設計**：透過 BFF（Backend for Frontend）模式解決前後端分離的複雜性
-- **資安防護機制**：實現 CSP、Rate Limiting、Cookie 安全等完整的資安防護體系
-
-**3. 滿足了什麼需求？**
-- **求職者需求**：提供低風險的職業探索機會，降低轉職成本與錯聘風險
-- **企業需求**：建立低成本的人才篩選機制，提升招聘效率與精準度
-- **平台管理需求**：實現自動化審核流程與人工覆核機制，確保內容品質
-- **技術需求**：採用現代化技術棧，確保系統的可維護性、擴展性與效能
-
-### 建議體驗流程
-1. 首頁探索 → 了解平台理念與合作夥伴
-2. 角色選擇 → 選擇體驗者或企業身份
-3. 註冊登入 → 完成身份驗證
-4. 瀏覽計畫 → 探索適合的體驗機會
-5. 申請參與 → 提交申請並等待審核
-6. 體驗回饋 → 完成體驗後撰寫評價
+> **一個連結人才與企業的創新平台**  
+> 提供短期職業體驗機會，讓求職者「先體驗、後決定」，降低轉職風險
 
 ---
 
-## 快速開始
+## 🎯 平台核心價值
+
+### 對求職者的價值
+- ✅ **低風險探索**：短期體驗，無需長期承諾
+- ✅ **真實職場體驗**：實際工作內容，非紙上談兵
+- ✅ **降低轉職成本**：避免入職後才發現不適合
+
+### 對企業的價值
+- ✅ **精準人才篩選**：透過實際表現評估適合度
+- ✅ **降低錯聘風險**：減少不適合人選的招聘成本
+- ✅ **提升招聘效率**：直接接觸有興趣的候選人
+
+---
+
+## 🏆 專案成果
+
+### 1. 完成了什麼任務？
+- **兩端完整系統開發**：建構體驗者端、企業端兩個獨立但整合的系統
+- **職業體驗平台核心功能**：實現先體驗後聘用的創新求職模式
+- **全端 Web 應用程式**：從前端 UI 到後端 API 的完整開發與部署（前後端分離架構）
+- **響應式設計實現**：支援桌機、平板、手機等多裝置體驗
+
+### 2. 開發過程中解決了什麼問題？
+- **跨端權限管理**：解決不同角色（體驗者、企業、管理員）的權限控制與路由保護
+- **API 架構設計**：透過 BFF（Backend for Frontend）模式解決前後端分離的複雜性
+- **資安防護機制**：實現中介層權限控制、API 錯誤處理等完整的資安防護體系
+- **開發效率優化**：透過現代化技術棧與工具鏈提升開發與維護效率
+
+### 3. 滿足了什麼需求？
+- **求職者需求**：提供低風險的職業探索機會，降低轉職成本與錯聘風險
+- **企業需求**：建立低成本的人才篩選機制，提升招聘效率與精準度
+- **技術需求**：採用現代化技術棧，確保系統的可維護性、擴展性與效能
+
+---
+
+## 📈 專案成果亮點
+
+| 項目 | 成果 |
+|------|------|
+| **系統完整性** | 34 個頁面、21 個元件、32 個 API 端點 |
+| **用戶體驗** | 響應式設計，支援桌機、平板、手機 |
+| **技術架構** | 現代化全端 Web 應用，前後端分離 |
+| **安全性** | 完整的權限控制與錯誤處理機制 |
+| **整合能力** | Google OAuth 登入、第三方支付整合 |
+
+---
+
+## 🛠️ 技術架構概覽
+
+### 前端技術棧
+- **核心框架**：Nuxt 3（^3.17.6）+ Vue 3（^3.5）+ TypeScript
+- **UI 設計**：Tailwind CSS + Element Plus（`idInjection: false`）
+- **狀態管理**：Pinia（含 `@pinia-plugin-persistedstate/nuxt`）
+- **圖片優化**：Nuxt Image（Vercel 圖片優化、遠端圖片白名單、預設輸出 webp）
+- **SEO 優化**：Nuxt SEO（`@nuxtjs/seo`、`@nuxtjs/sitemap`）
+- **字體管理**：`@nuxt/fonts`（Google Fonts：Inter）
+- **圖標系統**：Font Awesome（自訂插件註冊）
+- **日期處理**：dayjs（插件擴充 `updateLocale`、`relativeTime`、`utc`）
+- **認證整合**：Google OAuth（`@sidebase/nuxt-auth`、`next-auth`）
+- **AI 協作**：MCP 整合（`nuxt-mcp`）
+
+### 後端架構
+- **API 代理**：Nitro Server（BFF 模式）
+- **路由規則**：
+  - `/api-proxy/**` → 代理至 `https://trybeta.rocket-coding.com/**`
+  - `/img/**`、`/_vercel/image/**` → 長時間快取 headers
+- **SSR 轉譯**：`@popperjs/core`、`element-plus`
+- **遠端圖片來源**：`trybeta.rocket-coding.com`、`images.unsplash.com`、`i.imgur.com`
+- **圖片優化**：Vercel 圖片優化服務，支援多種螢幕尺寸響應式輸出
+
+### API 呼叫策略
+- **統一請求**：使用 `$fetch` 進行 HTTP 請求，透過 BFF 架構處理
+- **環境區分**：
+  - 開發環境：`baseURL = /api`，由 Nitro 代理轉發至真實後端
+  - 生產環境：`baseURL = NUXT_PUBLIC_API_BASE`
+- **代理處理**：後端實際路徑透過 Nitro 代理處理，開發環境使用 `/api-proxy/api/v1/...` 格式
+- **錯誤處理**：401 錯誤統一攔截，依請求前綴自動導向對應登入頁面
+
+### 開發工具
+- **程式碼品質**：ESLint 9（整合 `@nuxt/eslint`，Tab 縮排、不使用分號）
+- **測試框架**：Vitest（含覆蓋率報告）
+- **部署平台**：Vercel
+- **版本控制**：Git + Conventional Commits
+
+---
+
+## 🚀 快速開始
 
 ### 環境需求
 - Node.js 18+
 - pnpm 9.9.0+
-- Git
 
-### 安裝與啟動
+### 安裝步驟
 ```bash
-# 取得程式碼
+# 1. 取得程式碼
 git clone [repository-url]
 cd try-b
 
-# 安裝依賴
-pnpm install
-
-# 啟動開發伺服器
+# 2. 啟動開發伺服器
 pnpm dev
 
-# 建置正式版
+# 3. 建置正式版
 pnpm build
-
-# 本機預覽產出
-pnpm preview
 ```
 
-### 環境變數
-本專案使用 Nuxt Runtime Config：
-- `NUXT_PUBLIC_API_BASE_URL`：生產環境的後端 API 主機，預設為 `https://trybeta.rocket-coding.com`
-
-在開發環境時，所有 API 請求會透過 Nitro 代理 `/api-proxy/**` 轉發到真實後端；生產環境則直接使用 `NUXT_PUBLIC_API_BASE_URL`。
+### 環境變數設定
+```env
+NUXT_PUBLIC_API_BASE=/api
+NUXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
+NUXT_GOOGLE_CLIENT_SECRET=your_google_client_secret
+```
 
 ---
 
-## 專案規模統計
+## 🎨 系統功能特色
 
-### 開發成果
-- **頁面開發統計**：30+ 個完整頁面
-- **元件庫統計**：20+ 個可重用元件
-- **API 端點統計**：20+ 個不重複的 API endpoint
+### 👥 多角色系統
+- **體驗者端**：瀏覽計畫、申請參與、撰寫評價
+- **企業端**：發布計畫、管理申請者、查看評價
+
+
+### 🔐 安全機制
+- **權限控制**：基於角色的路由保護
+- **錯誤處理**：統一的 API 錯誤攔截與導向
+- **資料保護**：安全的 Cookie 設定與請求追蹤
+
+### 📱 用戶體驗
+- **響應式設計**：適配各種裝置尺寸
+- **圖片優化**：自動格式轉換與快取
+- **SEO 友善**：自動生成 sitemap 與 meta 標籤
+
+---
+
+## 📊 專案統計
+
+- **開發時間**：完整的前後端開發週期
+- **程式碼規模**：34 頁面 + 21 元件 + 32 API
+- **技術債務**：低，採用現代化技術棧
+- **維護性**：高，清晰的架構與完整的測試
+
+### 開發成果統計
+- **頁面開發**：34 個完整頁面
+- **元件庫**：21 個可重用元件
+- **API 端點**：32 個不重複的 API endpoint
+- **佈局系統**：6 種不同佈局 (main/company/user/admin/default/blank)
 
 ### 系統架構
-- **佈局系統**：6 種不同佈局 (main/company/user/admin/default/blank)
 - **兩端完整系統**：體驗者端、企業端
 - **BFF 架構**：實現 Backend for Frontend 代理層
+- **權限管理**：跨端權限控制與路由保護
+- **響應式設計**：支援桌機、平板、手機等多裝置體驗
 
 ---
 
-## 技術棧與主要模組
+## 🔧 開發規範
 
-### 前端
-- Nuxt 3（^3.17.6）
-- Vue 3（^3.5）
-- TypeScript
-- Tailwind CSS（整合 `@nuxtjs/tailwindcss`）
-- Element Plus（`@element-plus/nuxt`，`idInjection: false`）
-- Pinia（含 `@pinia-plugin-persistedstate/nuxt`）
-- Nuxt Image（`@nuxt/image`，IPX、遠端圖片白名單、預設輸出 webp、快取 header）
-- Nuxt SEO（`@nuxtjs/seo`、`@nuxtjs/sitemap`，站點 URL: `https://try-b.vercel.app`）
-- `@nuxt/fonts`（Google Fonts：Inter）
-- Font Awesome（自訂插件註冊 `font-awesome-icon`）
-- 日期處理：`dayjs`（插件擴充 `updateLocale`、`relativeTime`、`utc`）
-- Nuxt Security（`nuxt-security`，CSP、Rate Limiting、SRI 等資安功能）
+### 程式碼風格
+- Tab 縮排、不使用分號
+- TypeScript 嚴格模式
+- ESLint 自動檢查與修復
 
-### 開發工具
-- ESLint 9（整合 `@nuxt/eslint`，專案使用 Tab 縮排、不使用分號等 stylistic 設定）
-- Vitest（測試框架，含覆蓋率報告）
+### Git 工作流程
+- **分支策略**：feature/ → develop → main
+- **提交規範**：Conventional Commits
+- **代碼審查**：PR 必須通過測試
 
-### 伺服器端（Nuxt Nitro）BFF - Backend for Frontend
-- 以 Nitro Server 端點作為 API 代理層（例如：`server/api/v1/home/popular.get.ts`）
-- 路由規則：
-  - `/api-proxy/**` → 代理至 `https://trybeta.rocket-coding.com/**`
-  - `/img/**`、`/_ipx/**` → 長時間快取 headers
-- SSR 轉譯：`@popperjs/core`、`element-plus`
-- 允許的遠端圖片來源：`trybeta.rocket-coding.com`、`images.unsplash.com`、`i.imgur.com`
+#### Git Flow 詳細流程
+1. 從 `develop` 建立功能分支
+2. 功能完成於分支上
+3. 建立 PR 回 `develop`
+4. 測試通過後合併
+5. 週期性由 `develop` 併入 `main`
 
-### 資安防護
-- **Content Security Policy (CSP)**：Strict CSP 模式，包含 nonce 支援
-- **Subresource Integrity (SRI)**：確保外部資源完整性
-- **Rate Limiting**：每分鐘 100 請求限制，使用 LRU Cache 存儲
-- **Cookie 安全設定**：httpOnly、secure、sameSite 防護
-- **請求升級**：自動將 HTTP 升級為 HTTPS
-- **腳本限制**：禁止內聯腳本屬性、物件嵌入、base 標籤
-- **統一 API 錯誤處理**：請求追蹤與錯誤分類機制
-
----
-
-## API 架構與開發約定
-
-### 呼叫策略
-- 統一使用 `$fetch` 進行 HTTP 請求，透過 BFF 架構處理 API 調用
-- 開發環境（`NODE_ENV=development`）：`baseURL = /api-proxy`，由 Nitro 代理轉發至真實後端
-- 生產環境（`NODE_ENV=production`）：`baseURL = NUXT_PUBLIC_API_BASE_URL`
-- 後端實際路徑需包含 `api`（例如：`/api/v1/...`），並透過代理形如：`/api-proxy/api/v1/...`
-
-### 權限與錯誤處理
-- 401 錯誤統一在前端插件攔截（`plugins/api.ts`），依請求前綴自動導向：
-  - `/api/user` → 轉導 `users/login`
-  - `/api/company` → 轉導 `company/login`
-- 導轉附帶 `?redirect=<當前路徑>` 以便登入後回跳。
-
-### UI 與金流/金額顯示慣例
-- Element Plus 優先採用預設設定；盡量避免以 Tailwind 覆寫其元件樣式，僅在自行撰寫的容器元素（如 `div`、`span`）上酌量使用 Tailwind。
-- 金額顯示一律使用「TWD」作為國際貨幣前綴（例如：`TWD 1,000`）。
-
----
-
-## 專案腳本
-- `pnpm dev`：本機開發
-- `pnpm build`：建置
-- `pnpm preview`：本機預覽產出
-- `pnpm generate`：靜態化（如需）
-- `pnpm lint` / `pnpm lint:fix`：程式碼風格與修復
-- `pnpm test`：執行測試
-- `pnpm test:coverage`：測試覆蓋率報告
-
----
-
-## 目錄結構（節錄）
-
-```
-try-b/
-├── assets/            # 靜態資源（CSS、圖片）
-├── components/        # Vue 元件（company/shared/users）
-├── composables/       # 組合式函數（含 api 封裝）
-├── layouts/           # 頁面佈局（main/company/user/admin/default/blank）
-├── middleware/        # 路由中介軟體（company-auth、user-auth 等）
-├── pages/             # 頁面（admin/company/users...）
-├── plugins/           # Nuxt 插件（api、dayjs、fontawesome、error-handler）
-├── public/            # 靜態公開資源（favicon、_robots.txt、img/*）
-├── server/            # Nitro API 代理端點（/api/v1/**）
-├── stores/            # Pinia 狀態（user/company/admin）
-├── types/             # TypeScript 型別
-├── utils/             # 工具函數
-└── test/              # 測試檔案
-```
-
----
-## Public 資料夾（重點）
-- `favicon.ico`：網站小圖示
-- `_robots.txt`：搜尋引擎爬蟲規則
-- `img/`：站內靜態圖片（如 `home/`、`company/`、`admin/`、`users/` 等）
-  - 重要：Nitro 針對 `/img/**` 與 `/_ipx/**` 已設定長時間快取 headers
-  - Nuxt Image 透過 IPX 處理圖片輸出與格式（預設輸出 webp、quality=80）
-
----
-
-## 路由與頁面
-- `pages/users/*`：使用者端（登入、收藏、申請、計畫詳情、設定、評論等）
-- `pages/company/*`：企業端（登入、計畫建立/管理、申請者管理、購買流程、評論等）
-- `pages/admin/*`：管理員端（儀表板、評論審核、計畫管理、趨勢）
-
-對應中介層：
-- `middleware/user-auth.ts`：使用者權限
-- `middleware/company-auth.global.ts`：企業權限
-- `middleware/company-purchase-first-visit.global.ts`：首次購買流程限制
-
----
-
-## 程式碼風格
-- 使用 ESLint 9 與 `@nuxt/eslint` 預設規範；專案 stylistic 設定包含：
-  - Tab 縮排
-  - 不使用分號
-  - 多行結尾使用尾逗號
-- 環境區分：開發/生產環境使用不同的 ESLint 規則嚴格度
-
----
-
-## Git 規範
-
-### Commit（Conventional Commits）
+#### Commit 規範
 - `feat:` 新功能
 - `fix:` 修復問題
 - `docs:` 文件更新
@@ -210,32 +187,65 @@ try-b/
 - `test:` 測試相關
 - `chore:` 建置/工具
 
-### Branch
-- `main`：生產分支
-- `develop`：開發分支
-- `feature/*`：功能開發
-- `fix/*`：修復
-- `hotfix/*`：緊急修復
-
-### Git Flow（建議）
-1. 從 `develop` 建立功能分支
-2. 功能完成於分支上
-3. 建立 PR 回 `develop`
-4. 測試通過後合併
-5. 週期性由 `develop` 併入 `main`
+### 測試策略
+- **單元測試**：Vitest 框架
+- **覆蓋率報告**：`pnpm test:coverage`
+- **持續整合**：自動化測試與部署
 
 ---
 
-## 部署建議
-- 以 Vercel/Nitro 為主的部署流程；請確認：
-  - `NUXT_PUBLIC_API_BASE_URL` 已設定
-  - 需要代理的路由維持 `/api-proxy/**` → 真實後端
-  - 網站 URL（`nuxt.config.ts` 中 `site.url`）與實際網域一致
+## 📁 專案目錄結構
+
+```
+try-b/
+├── assets/            # 靜態資源（CSS、圖片）
+├── components/        # Vue 元件
+│   ├── auth/         # 認證相關元件
+│   ├── company/      # 企業端元件
+│   ├── shared/       # 共用元件
+│   └── users/        # 使用者端元件
+├── composables/       # 組合式函數
+│   └── api/          # API 封裝
+├── layouts/           # 頁面佈局
+│   ├── main.vue      # 主佈局
+│   ├── company.vue   # 企業端佈局
+│   ├── user.vue      # 使用者端佈局
+│   ├── admin.vue     # 管理員佈局
+│   ├── default.vue   # 預設佈局
+│   └── blank.vue     # 空白佈局
+├── middleware/        # 路由中介軟體
+├── pages/             # 頁面路由
+│   ├── admin/        # 管理員頁面
+│   ├── company/      # 企業端頁面
+│   └── users/        # 使用者端頁面
+├── plugins/           # Nuxt 插件
+├── public/            # 靜態公開資源
+├── server/            # Nitro API 端點
+├── stores/            # Pinia 狀態管理
+├── types/             # TypeScript 型別定義
+├── utils/             # 工具函數
+└── test/              # 測試檔案
+```
+
+### 重要資料夾說明
+- **`public/img/`**：站內靜態圖片，支援長時間快取
+- **`server/api/v1/`**：API 代理端點，統一處理後端請求
+- **`middleware/`**：權限控制與路由保護
+- **`composables/api/`**：API 封裝，統一錯誤處理
 
 ---
 
-## 備註
-- 設計工具（Figma、Miro 等）未納入此程式倉庫，若需補充請於此區更新
-- 若需擴充 API，請遵循現有模式：優先 `$fetch`、路徑需含 `api`、開發環境使用 `/api-proxy` 代理、並延續錯誤攔截與導流行為
-- 專案已實現完整的資安防護機制，包括 CSP、認證、速率限制等
-- 測試覆蓋率報告可透過 `pnpm test:coverage` 查看
+## 🚀 部署與維護
+
+### 部署平台
+- **主要平台**：Vercel
+- **CDN 加速**：全球節點分發
+- **自動部署**：Git push 觸發
+
+### 監控與維護
+- **效能監控**：Vercel Analytics
+- **錯誤追蹤**：統一的錯誤處理機制
+- **日誌記錄**：API 請求追蹤
+
+
+*最後更新：2025-10-21*


### PR DESCRIPTION
重構 README.md 文件結構，針對人力資源專員的閱讀習慣進行優化：

主要變更：
- 重新設計視覺層次，使用 emoji 圖標與表格提升可讀性
- 新增「平台核心價值」區塊，明確說明對求職者與企業的價值
- 保留「專案成果」三大核心問題：完成任務、解決問題、滿足需求
- 整合技術架構說明，包含前端技術棧、後端架構、API 呼叫策略
- 新增專案目錄結構與重要資料夾說明
- 完善 Git Flow 工作流程與 Commit 規範
- 簡化安裝步驟，移除 pnpm install 說明
- 更新統計數據：34 頁面、21 元件、32 API 端點

決策理由：
- 針對 HR 專員 3-5 分鐘閱讀時間限制進行優化
- 平衡技術細節與商業價值說明
- 保持文件完整性同時提升專業形象
- 使用現代化 Markdown 格式增強視覺吸引力