### PR TITLE
feat(auth): 更新使用者名稱映射至後端 Name 欄位

### DIFF
--- a/composables/api/users/useUserLogin.ts
+++ b/composables/api/users/useUserLogin.ts
@@ -5,6 +5,7 @@ interface ApiUser {
 	Id: number
 	Account: string
 	Email: string
+	Name: string
 	Role: string
 }
 

--- a/stores/user/useAuthStore.ts
+++ b/stores/user/useAuthStore.ts
@@ -29,7 +29,7 @@ export const useUserAuthStore = defineStore('userAuth', () => {
 				// 將 API 回應的 user 格式轉換為內部 User 格式
 				const mappedUser: User = {
 					id: response.user.Id,
-					name: response.user.Account,
+					name: response.user.Name,
 					account: response.user.Account,
 					email: response.user.Email,
 					role: response.user.Role,
@@ -56,6 +56,7 @@ export const useUserAuthStore = defineStore('userAuth', () => {
 			Id: number
 			Account: string
 			Email: string
+			Name: string
 			Role: string
 		}
 	}) {
@@ -68,7 +69,7 @@ export const useUserAuthStore = defineStore('userAuth', () => {
 				// 將 API 回應的 user 格式轉換為內部 User 格式
 				const mappedUser: User = {
 					id: googleResponse.user.Id,
-					name: googleResponse.user.Account,
+					name: googleResponse.user.Name,
 					account: googleResponse.user.Account,
 					email: googleResponse.user.Email,
 					role: googleResponse.user.Role,

--- a/types/users/user.ts
+++ b/types/users/user.ts
@@ -1,6 +1,6 @@
 // import type { CompanyUser } from './company';
 
-// Based on the API spec for user registration and login
+// Based on the API spec for user registration and login -- credentials login
 export interface User {
 	id: number
 	name: string
@@ -16,6 +16,15 @@ export interface User {
 export interface UserRegisterData extends UserLoginData {
 	name: string
 	email: string
+}
+
+// 後端 API response 的 user 物件結構 (對齊 API 規格) -- google login
+export interface ApiUserResponse {
+	Id: number
+	Account: string
+	Email: string
+	Name: string
+	Role: string
 }
 
 // Based on the request body for user login API (assumed)


### PR DESCRIPTION
修正 Google OAuth2 與一般登入流程的使用者名稱顯示問題：
UI 將顯示真實姓名 (如 "Adam Chou") 而非 email 地址。

決策:
- 新增 ApiUserResponse 型別介面，對齊後端 API 規格
- 將 login() 和 loginWithGoogleToken() 的 user.name 映射 從 Account (email) 改為 Name (真實姓名)
- 更新 useUserLogin.ts 的 ApiUser 介面，新增 Name 欄位

理由:
- 後端 API response 已包含 Name 欄位，前端應正確使用
- 符合使用者體驗期望，顯示真實姓名更友善
- 保持前端 User 介面與後端 API response 結構一致性

其他補充:
- 修改檔案: types/users/user.ts, stores/user/useAuthStore.ts, composables/api/users/useUserLogin.ts
- 變更統計: 3 files changed, 14 insertions(+), 3 deletions(-)
- 已通過 pnpm type-check 驗證，無 TypeScript 錯誤