### PR TITLE
fix(payment): 調整藍新金流表單提交方式，改為當前視窗提交

### DIFF
--- a/composables/api/company/useCompanyPayment.ts
+++ b/composables/api/company/useCompanyPayment.ts
@@ -178,7 +178,8 @@ Vercel 區域: ${apiError.error?.vercelRegion}
 		form.method = 'POST'
 		form.action = payGetWay
 		form.style.display = 'none'
-		form.target = '_blank' // 在新視窗開啟藍新金流頁面
+		// 移除 target='_blank'，改為在當前視窗提交，讓藍新金流完成後能回到原付款頁面
+		form.target = '_self' // 預設就是當前視窗，可以不設定
 
 		// 根據藍新金流 MPG 交易規範添加表單欄位
 		// MerchantID: 商店代號

--- a/docs/newebpay-integration.md
+++ b/docs/newebpay-integration.md
@@ -14,7 +14,7 @@
 ### 4-2 MPG 交易
 - **表單提交**：使用 POST 方法提交到藍新金流閘道
 - **必要欄位**：MerchantID、TradeInfo、TradeSha、Version
-- **目標視窗**：在新視窗開啟藍新金流付款頁面
+- **目標視窗**：在當前視窗提交，確保付款完成後能正確返回原頁面
 
 ### 4-2-2 付款完成回調機制
 根據藍新金流文件，有兩種回調方式：
@@ -96,7 +96,7 @@ const submitToNewebPay = (paymentData: NewebPayFormData, payGetWay: string): voi
   const form = document.createElement('form')
   form.method = 'POST'
   form.action = payGetWay
-  form.target = '_blank' // 在新視窗開啟
+  // 在當前視窗提交，讓藍新金流完成後能回到原付款頁面
   
   // 添加必要欄位
   // MerchantID, TradeInfo, TradeSha, Version
@@ -199,7 +199,7 @@ ReturnURL: "https://try-b.vercel.app/api/v1/company/payments/return"
 
 1. **加解密處理**：前端不處理加解密，由後端負責
 2. **表單提交**：使用隱藏表單自動提交到藍新金流
-3. **視窗管理**：在新視窗開啟藍新金流頁面
+3. **視窗管理**：在當前視窗提交，確保付款完成後能正確返回原頁面
 4. **狀態管理**：付款成功後更新企業方案狀態
 
 ## 開發建議


### PR DESCRIPTION
修復藍新金流付款流程中的使用者體驗問題：
原本付款完成後會在新視窗開啟成功頁面，
導致使用者需要手動切換視窗，造成流程中斷。

決策：
  - 移除 form.target = '_blank' 設定
  - 明確設定 form.target = '_self' 確保在當前視窗提交
  - 更新相關技術文檔以反映此變更

理由：
  1. 提升使用者體驗一致性： 付款流程應在同一個瀏覽器視窗中完成， 讓使用者能清楚看到完整的付款流程狀態

  2. 符合常見的支付流程模式： 大多數支付系統都會在同一視窗完成付款流程， 此調整讓行為符合使用者預期

  3. 簡化視窗管理： 避免多個視窗造成的混亂，減少使用者操作負擔

其他補充：
  - 修改檔案：
    * composables/api/company/useCompanyPayment.ts
      - 移除 target='_blank' 設定
      - 新增註釋說明變更原因
    * docs/newebpay-integration.md - 更新三處文檔描述（目標視窗、程式碼範例、注意事項） - 將「在新視窗開啟」改為「在當前視窗提交」

  - 影響範圍：
    * 企業端付款頁面（/company/purchase/payment）
    * 藍新金流付款完成後的返回流程
    * 使用者體驗改善，無需調整後端 API

  - 測試建議：
    * 確認付款流程在單一視窗中完成
    * 驗證付款完成後正確返回成功頁面
    * 檢查所有付款方式的行為一致性